### PR TITLE
fix(client): use Torii GraphQL for game tokens and leaderboard

### DIFF
--- a/client-budokan/src/hooks/useGameTokensSlot.ts
+++ b/client-budokan/src/hooks/useGameTokensSlot.ts
@@ -3,18 +3,14 @@ import { useEffect, useState, useCallback } from "react";
 import { getComponentValue, Has, runQuery } from "@dojoengine/recs";
 import type { GameTokenData } from "metagame-sdk";
 
-const { VITE_PUBLIC_DEPLOY_TYPE } = import.meta.env;
+const { VITE_PUBLIC_DEPLOY_TYPE, VITE_PUBLIC_TORII, VITE_PUBLIC_GAME_TOKEN_ADDRESS } = import.meta.env;
 export const isSlotMode = VITE_PUBLIC_DEPLOY_TYPE === "slot";
 
-// Normalize address for comparison (remove leading zeros, lowercase)
-const normalizeAddress = (address: string | bigint | undefined): string => {
+// Pad address to 66 characters (0x + 64 hex chars)
+const padAddress = (address: string): string => {
   if (!address) return "";
-  const hex = typeof address === "bigint" 
-    ? address.toString(16) 
-    : address.startsWith("0x") 
-      ? address.slice(2) 
-      : address;
-  return `0x${hex.replace(/^0+/, "").toLowerCase()}`;
+  const hex = address.startsWith("0x") ? address.slice(2) : address;
+  return `0x${hex.padStart(64, "0")}`;
 };
 
 type UseGameTokensSlotResult = {
@@ -24,10 +20,55 @@ type UseGameTokensSlotResult = {
   refetch: () => void;
 };
 
+// GraphQL query for ERC721 token balances
+const TOKEN_BALANCES_QUERY = `
+  query GetTokenBalances($accountAddress: String!, $limit: Int) {
+    tokenBalances(accountAddress: $accountAddress, limit: $limit) {
+      edges {
+        node {
+          tokenMetadata {
+            __typename
+            ... on ERC721__Token {
+              tokenId
+              contractAddress
+              metadata
+              metadataName
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+interface ERC721TokenMetadata {
+  __typename: "ERC721__Token";
+  tokenId: string;
+  contractAddress: string;
+  metadata: string;
+  metadataName: string;
+}
+
+interface TokenBalanceNode {
+  tokenMetadata: ERC721TokenMetadata | { __typename: string };
+}
+
+interface TokenBalancesResponse {
+  data?: {
+    tokenBalances?: {
+      edges: Array<{ node: TokenBalanceNode }>;
+    };
+  };
+  errors?: Array<{ message: string }>;
+}
+
 /**
- * Hook for fetching games directly from RECS (Torii).
+ * Hook for fetching game tokens directly from Torii GraphQL.
  * Works on slot mode by default, but can be forced on other networks via `forceRecs`.
  * This is a fallback approach that works without the metagame relayer.
+ * 
+ * Uses Torii's tokenBalances query to get owned ERC721 tokens, then matches
+ * with Game model data from RECS for additional game state info.
  */
 export const useGameTokensSlot = ({
   owner,
@@ -40,14 +81,13 @@ export const useGameTokensSlot = ({
   limit?: number;
   includeMetadata?: boolean;
   gameAddresses?: string[];
-  forceRecs?: boolean; // Force RECS query even on non-slot modes
+  forceRecs?: boolean; // Force query even on non-slot modes
 }): UseGameTokensSlotResult => {
   const {
     setup: {
       clientModels: {
         models: { Game },
       },
-      world,
     },
   } = useDojo();
 
@@ -67,64 +107,132 @@ export const useGameTokensSlot = ({
       return;
     }
 
-    const fetchGames = () => {
+    const fetchGames = async () => {
       setLoading(true);
       try {
+        const toriiUrl = VITE_PUBLIC_TORII;
+        const gameTokenAddress = VITE_PUBLIC_GAME_TOKEN_ADDRESS?.toLowerCase();
+        
+        if (!toriiUrl) {
+          console.warn("[useGameTokensSlot] No TORII URL configured");
+          setGames([]);
+          return;
+        }
+
+        // Pad the owner address for Torii query
+        const paddedOwner = padAddress(owner!);
+        
+        console.log("[useGameTokensSlot] Fetching ERC721 tokens for owner:", paddedOwner);
+
+        // Query Torii GraphQL for token balances
+        const response = await fetch(`${toriiUrl}/graphql`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            query: TOKEN_BALANCES_QUERY,
+            variables: { accountAddress: paddedOwner, limit },
+          }),
+        });
+
+        if (!response.ok) {
+          throw new Error(`Torii GraphQL request failed: ${response.status}`);
+        }
+
+        const result: TokenBalancesResponse = await response.json();
+
+        if (result.errors?.length) {
+          console.error("[useGameTokensSlot] GraphQL errors:", result.errors);
+          throw new Error(result.errors[0].message);
+        }
+
+        const edges = result.data?.tokenBalances?.edges || [];
+        
+        // Filter for ERC721 tokens from our game contract
+        const erc721Tokens = edges
+          .map((edge) => edge.node.tokenMetadata)
+          .filter((meta): meta is ERC721TokenMetadata => {
+            if (meta.__typename !== "ERC721__Token") return false;
+            // Filter by game token contract if configured
+            if (gameTokenAddress) {
+              const tokenContract = (meta as ERC721TokenMetadata).contractAddress?.toLowerCase();
+              return tokenContract?.includes(gameTokenAddress.replace("0x", ""));
+            }
+            return true;
+          });
+
+        console.log("[useGameTokensSlot] Found ERC721 tokens:", erc721Tokens.length);
+
+        // Get owned token IDs
+        const ownedTokenIds = new Set(
+          erc721Tokens.map((token) => {
+            // tokenId is hex string like "0x0000...0001"
+            return Number(BigInt(token.tokenId));
+          })
+        );
+
         // Query all Game entities from RECS
         const gameEntities = runQuery([Has(Game)]);
 
         const gameList: GameTokenData[] = [];
         const seenIds = new Set<number>();
-        const normalizedOwner = normalizeAddress(owner);
-
-        console.log("[useGameTokensSlot] Fetching games for owner:", normalizedOwner);
 
         for (const entity of gameEntities) {
           const gameData = getComponentValue(Game, entity);
 
           if (!gameData || gameData.game_id === 0) continue;
 
-          // Deduplicate by game_id (RECS may have multiple entities for same game)
+          // Only include games owned by the user
+          if (!ownedTokenIds.has(gameData.game_id)) continue;
+
+          // Deduplicate by game_id
           if (seenIds.has(gameData.game_id)) continue;
           seenIds.add(gameData.game_id);
 
-          // Skip games that haven't started (blocks == 0)
-          if (gameData.blocks === 0n) continue;
+          // Find the token metadata from Torii response
+          const tokenMeta = erc721Tokens.find(
+            (t) => Number(BigInt(t.tokenId)) === gameData.game_id
+          );
 
-          // NOTE: Game model doesn't have a player field - ownership is tracked by ERC721 token
-          // For now, we show all games. In production, query the token contract for ownership
-          // or use metagame-sdk which handles this properly.
+          // Parse metadata from token if available
+          let parsedMetadata: Record<string, unknown> | undefined;
+          if (tokenMeta?.metadata) {
+            try {
+              parsedMetadata = JSON.parse(tokenMeta.metadata);
+            } catch {
+              // Ignore parse errors
+            }
+          }
 
-          // Extract level data from run_data
-          // See contracts/src/helpers/packing.cairo for bit layout
+          // Extract level data from run_data as fallback
           const runData = gameData.run_data ? BigInt(gameData.run_data) : BigInt(0);
-          // Unpack run_data fields (from RunDataBits in packing.cairo):
-          // bits 0-7 = current_level (8 bits)
-          // bits 99-114 = cubes_brought (16 bits)
-          // bits 115-130 = cubes_spent (16 bits)
-          // bits 131-146 = total_cubes (16 bits)
-          // bits 147-162 = total_score (16 bits)
-          const level = Number(runData & BigInt(0xFF)); // 8 bits at position 0
-          const cubesBrought = Number((runData >> BigInt(99)) & BigInt(0xFFFF)); // 16 bits at position 99
-          const cubesSpent = Number((runData >> BigInt(115)) & BigInt(0xFFFF)); // 16 bits at position 115
-          const totalCubes = Number((runData >> BigInt(131)) & BigInt(0xFFFF)); // 16 bits at position 131
-          const totalScore = Number((runData >> BigInt(147)) & BigInt(0xFFFF)); // 16 bits at position 147
+          const level = Number(runData & BigInt(0xFF));
+          const cubesBrought = Number((runData >> BigInt(99)) & BigInt(0xFFFF));
+          const cubesSpent = Number((runData >> BigInt(115)) & BigInt(0xFFFF));
+          const totalCubes = Number((runData >> BigInt(131)) & BigInt(0xFFFF));
+          const totalScore = Number((runData >> BigInt(147)) & BigInt(0xFFFF));
+
+          // Use token metadata if available, otherwise construct from game data
+          const metadata = parsedMetadata 
+            ? JSON.stringify(parsedMetadata)
+            : JSON.stringify({
+                name: `Game #${gameData.game_id}`,
+                attributes: [
+                  { trait_type: "Level", value: level },
+                  { trait_type: "Total Cubes", value: totalCubes },
+                  { trait_type: "Total Score", value: totalScore },
+                  { trait_type: "Cubes Brought", value: cubesBrought },
+                  { trait_type: "Cubes Spent", value: cubesSpent },
+                ],
+              });
 
           gameList.push({
             token_id: gameData.game_id,
             score: totalScore,
             game_over: gameData.over,
-            metadata: JSON.stringify({
-              name: `Game #${gameData.game_id}`,
-              attributes: [
-                { trait_type: "Level", value: level },
-                { trait_type: "Total Cubes", value: totalCubes },
-                { trait_type: "Total Score", value: totalScore },
-                { trait_type: "Cubes Brought", value: cubesBrought },
-                { trait_type: "Cubes Spent", value: cubesSpent },
-              ],
-            }),
-            gameMetadata: { name: `Game #${gameData.game_id}` },
+            metadata,
+            gameMetadata: { 
+              name: tokenMeta?.metadataName || `Game #${gameData.game_id}` 
+            },
           } as GameTokenData);
 
           if (gameList.length >= limit) break;
@@ -133,9 +241,10 @@ export const useGameTokensSlot = ({
         // Sort by token_id descending (newest first)
         gameList.sort((a, b) => b.token_id - a.token_id);
 
+        console.log("[useGameTokensSlot] Final game list:", gameList.length);
         setGames(gameList);
       } catch (error) {
-        console.error("Error fetching slot games:", error);
+        console.error("[useGameTokensSlot] Error fetching games:", error);
         setGames([]);
       } finally {
         setLoading(false);
@@ -143,7 +252,7 @@ export const useGameTokensSlot = ({
     };
 
     fetchGames();
-  }, [Game, owner, limit, world, refreshTrigger]);
+  }, [Game, owner, limit, refreshTrigger, shouldFetch]);
 
   return {
     games,

--- a/client-budokan/src/hooks/useGameTokensSlot.ts
+++ b/client-budokan/src/hooks/useGameTokensSlot.ts
@@ -91,11 +91,9 @@ export const useGameTokensSlot = ({
           // Skip games that haven't started (blocks == 0)
           if (gameData.blocks === 0n) continue;
 
-          // Filter by owner - only show games belonging to the current player
-          const gamePlayer = normalizeAddress(gameData.player);
-          if (normalizedOwner && gamePlayer !== normalizedOwner) {
-            continue;
-          }
+          // NOTE: Game model doesn't have a player field - ownership is tracked by ERC721 token
+          // For now, we show all games. In production, query the token contract for ownership
+          // or use metagame-sdk which handles this properly.
 
           // Extract level data from run_data
           // See contracts/src/helpers/packing.cairo for bit layout

--- a/client-budokan/src/hooks/useLeaderboardSlot.ts
+++ b/client-budokan/src/hooks/useLeaderboardSlot.ts
@@ -1,22 +1,15 @@
 import { useDojo } from "@/dojo/useDojo";
-import { useEffect, useState, useCallback, useMemo } from "react";
+import { useEffect, useState, useCallback } from "react";
 import { getComponentValue, Has, runQuery } from "@dojoengine/recs";
 import { lookupAddresses } from "@cartridge/controller";
-import { addAddressPadding } from "starknet";
 
-const { VITE_PUBLIC_DEPLOY_TYPE } = import.meta.env;
+const { VITE_PUBLIC_DEPLOY_TYPE, VITE_PUBLIC_TORII, VITE_PUBLIC_GAME_TOKEN_ADDRESS } = import.meta.env;
 export const isSlotMode = VITE_PUBLIC_DEPLOY_TYPE === "slot";
 
 // Truncate address to 0x1234...5678 format
 const truncateAddress = (address: string): string => {
   if (!address || address.length <= 13) return address || "Unknown";
   return `${address.slice(0, 6)}...${address.slice(-4)}`;
-};
-
-// Convert bigint to padded hex address
-const toHexAddress = (address: bigint | undefined): string => {
-  if (!address) return "";
-  return addAddressPadding(`0x${address.toString(16)}`);
 };
 
 export interface LeaderboardEntry {
@@ -29,6 +22,7 @@ export interface LeaderboardEntry {
   score: number; // Alias for totalScore for compatibility
   player_name?: string;
   player_address?: string; // Raw address for username lookup
+  owner?: string; // Token owner address
   started_at?: number;
 }
 
@@ -38,10 +32,74 @@ type UseLeaderboardSlotResult = {
   refetch: () => void;
 };
 
+// GraphQL query for all token transfers (mints from 0x0)
+const TOKEN_TRANSFERS_QUERY = `
+  query GetTokenTransfers($limit: Int) {
+    tokenTransfers(accountAddress: "0x0", limit: $limit) {
+      edges {
+        node {
+          from
+          to
+          tokenMetadata {
+            __typename
+            ... on ERC721__Token {
+              tokenId
+              contractAddress
+              metadata
+              metadataName
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+interface ERC721TokenMetadata {
+  __typename: "ERC721__Token";
+  tokenId: string;
+  contractAddress: string;
+  metadata: string;
+  metadataName: string;
+}
+
+interface TokenTransferNode {
+  from: string;
+  to: string;
+  tokenMetadata: ERC721TokenMetadata | { __typename: string };
+}
+
+interface TokenTransfersResponse {
+  data?: {
+    tokenTransfers?: {
+      edges: Array<{ node: TokenTransferNode }>;
+    };
+  };
+  errors?: Array<{ message: string }>;
+}
+
+// Parse player name from token metadata JSON
+const parsePlayerName = (metadata: string | undefined): string | undefined => {
+  if (!metadata) return undefined;
+  try {
+    const parsed = JSON.parse(metadata);
+    const attributes = parsed.attributes || [];
+    const playerNameAttr = attributes.find(
+      (attr: { trait?: string; trait_type?: string; value?: string }) =>
+        attr.trait === "Player Name" || attr.trait_type === "Player Name"
+    );
+    return playerNameAttr?.value;
+  } catch {
+    return undefined;
+  }
+};
+
 /**
  * Hook for fetching leaderboard data directly from RECS (Torii).
  * Works on slot mode by default, but can be forced on other networks via `forceRecs`.
- * Queries all Game entities and sorts by level -> cubes -> totalScore.
+ * Queries all Game entities and sorts by level -> totalScore -> totalCubes.
+ * 
+ * Uses Torii's tokenTransfers query to get token ownership and player names.
  */
 export const useLeaderboardSlot = ({ 
   forceRecs = false 
@@ -53,7 +111,6 @@ export const useLeaderboardSlot = ({
       clientModels: {
         models: { Game },
       },
-      world,
     },
   } = useDojo();
 
@@ -76,15 +133,67 @@ export const useLeaderboardSlot = ({
     const fetchGames = async () => {
       setLoading(true);
       try {
+        const toriiUrl = VITE_PUBLIC_TORII;
+        const gameTokenAddress = VITE_PUBLIC_GAME_TOKEN_ADDRESS?.toLowerCase();
+
+        // First, fetch token ownership data from Torii GraphQL
+        let tokenOwnerMap = new Map<number, { owner: string; playerName?: string }>();
+        
+        if (toriiUrl) {
+          try {
+            const response = await fetch(`${toriiUrl}/graphql`, {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({
+                query: TOKEN_TRANSFERS_QUERY,
+                variables: { limit: 500 },
+              }),
+            });
+
+            if (response.ok) {
+              const result: TokenTransfersResponse = await response.json();
+              const edges = result.data?.tokenTransfers?.edges || [];
+
+              for (const edge of edges) {
+                const meta = edge.node.tokenMetadata;
+                if (meta.__typename !== "ERC721__Token") continue;
+
+                const erc721Meta = meta as ERC721TokenMetadata;
+                
+                // Filter by game token contract if configured
+                if (gameTokenAddress) {
+                  const tokenContract = erc721Meta.contractAddress?.toLowerCase();
+                  if (!tokenContract?.includes(gameTokenAddress.replace("0x", ""))) continue;
+                }
+
+                const tokenId = Number(BigInt(erc721Meta.tokenId));
+                const owner = edge.node.to;
+                const playerName = parsePlayerName(erc721Meta.metadata);
+
+                tokenOwnerMap.set(tokenId, { owner, playerName });
+              }
+
+              console.log("[useLeaderboardSlot] Loaded token ownership for", tokenOwnerMap.size, "tokens");
+            }
+          } catch (error) {
+            console.error("[useLeaderboardSlot] Error fetching token data:", error);
+          }
+        }
+
         // Query all Game entities from RECS
         const gameEntities = runQuery([Has(Game)]);
 
         const gameList: LeaderboardEntry[] = [];
+        const seenIds = new Set<number>();
 
         for (const entity of gameEntities) {
           const gameData = getComponentValue(Game, entity);
 
           if (!gameData || gameData.game_id === 0) continue;
+
+          // Deduplicate
+          if (seenIds.has(gameData.game_id)) continue;
+          seenIds.add(gameData.game_id);
 
           // Skip games that haven't started
           if (gameData.blocks === 0n) continue;
@@ -92,15 +201,13 @@ export const useLeaderboardSlot = ({
           // Extract level data from run_data
           // See contracts/src/helpers/packing.cairo for bit layout (RunDataBits)
           const runData = gameData.run_data ? BigInt(gameData.run_data) : BigInt(0);
-          // Unpack run_data fields:
-          // bits 0-7 = current_level (8 bits)
-          // bits 131-146 = total_cubes (16 bits)
-          // bits 147-162 = total_score (16 bits)
           const level = Number(runData & BigInt(0xFF)); // 8 bits at position 0
           const totalCubes = Number((runData >> BigInt(131)) & BigInt(0xFFFF)); // 16 bits at position 131
           const totalScore = Number((runData >> BigInt(147)) & BigInt(0xFFFF)); // 16 bits at position 147
 
-          const playerAddress = toHexAddress(gameData.player);
+          // Get owner info from token data
+          const tokenInfo = tokenOwnerMap.get(gameData.game_id);
+          
           gameList.push({
             token_id: gameData.game_id,
             game_id: gameData.game_id,
@@ -109,8 +216,9 @@ export const useLeaderboardSlot = ({
             totalScore,
             gameOver: gameData.over || false,
             score: totalScore, // Alias for compatibility
-            player_address: playerAddress,
-            player_name: undefined, // Will be populated by username lookup
+            player_address: tokenInfo?.owner,
+            player_name: tokenInfo?.playerName,
+            owner: tokenInfo?.owner,
             started_at: gameData.started_at ? Number(gameData.started_at) : 0,
           });
         }
@@ -123,35 +231,44 @@ export const useLeaderboardSlot = ({
           return (a.started_at ?? 0) - (b.started_at ?? 0);
         });
 
-        // Batch lookup usernames for all player addresses
-        const addresses = gameList
-          .map((g) => g.player_address)
-          .filter((addr): addr is string => !!addr);
+        // Batch lookup usernames for addresses without player names
+        const addressesNeedingLookup = gameList
+          .filter((g) => g.player_address && !g.player_name)
+          .map((g) => g.player_address!)
+          .filter((addr, index, self) => self.indexOf(addr) === index); // Dedupe
         
-        if (addresses.length > 0) {
+        if (addressesNeedingLookup.length > 0) {
           try {
-            const usernameMap = await lookupAddresses(addresses);
+            const usernameMap = await lookupAddresses(addressesNeedingLookup);
             // Update games with resolved usernames
             for (const game of gameList) {
-              if (game.player_address) {
+              if (game.player_address && !game.player_name) {
                 const username = usernameMap.get(game.player_address);
                 game.player_name = username || truncateAddress(game.player_address);
               }
             }
           } catch (error) {
-            console.error("Error looking up usernames:", error);
+            console.error("[useLeaderboardSlot] Error looking up usernames:", error);
             // Fallback to truncated addresses
             for (const game of gameList) {
-              if (game.player_address) {
+              if (game.player_address && !game.player_name) {
                 game.player_name = truncateAddress(game.player_address);
               }
             }
           }
         }
 
+        // For games without any player info, show game ID
+        for (const game of gameList) {
+          if (!game.player_name) {
+            game.player_name = `Game #${game.token_id}`;
+          }
+        }
+
+        console.log("[useLeaderboardSlot] Final leaderboard:", gameList.length, "entries");
         setGames(gameList);
       } catch (error) {
-        console.error("Error fetching leaderboard games:", error);
+        console.error("[useLeaderboardSlot] Error fetching leaderboard:", error);
         setGames([]);
       } finally {
         setLoading(false);
@@ -159,7 +276,7 @@ export const useLeaderboardSlot = ({
     };
 
     fetchGames();
-  }, [Game, world, refreshTrigger]);
+  }, [Game, refreshTrigger, shouldFetch]);
 
   return {
     games,

--- a/client-budokan/src/ui/screens/Home.tsx
+++ b/client-budokan/src/ui/screens/Home.tsx
@@ -49,6 +49,14 @@ import {
 
 const gameSystemAddress = getGameSystemAddress();
 
+// Normalize address to remove leading zeros (matches Torii's format)
+const normalizeAddress = (address: string | undefined): string | undefined => {
+  if (!address) return undefined;
+  if (!address.startsWith("0x")) return address;
+  const hex = address.slice(2).replace(/^0+/, "") || "0";
+  return `0x${hex}`;
+};
+
 type TokenAttribute = {
   trait?: string;
   trait_type?: string;
@@ -159,9 +167,12 @@ export const Home = () => {
 
   const shouldFetchMyGames = Boolean(account?.address);
 
+  // Normalize address to match Torii's format (no leading zeros)
+  const normalizedOwner = normalizeAddress(account?.address);
+
   // Use metagame SDK for sepolia/mainnet
   const metagameResult = useGameTokens({
-    owner: !isSlotMode && shouldFetchMyGames ? account?.address : undefined,
+    owner: !isSlotMode && shouldFetchMyGames ? normalizedOwner : undefined,
     sortBy: "minted_at",
     sortOrder: "desc",
     limit: !isSlotMode && shouldFetchMyGames ? 100 : 0,
@@ -178,7 +189,7 @@ export const Home = () => {
 
   // Use RECS query for slot mode OR as fallback when metagame fails
   const slotResult = useGameTokensSlot({
-    owner: (isSlotMode || metagameFailed) && shouldFetchMyGames ? account?.address : undefined,
+    owner: (isSlotMode || metagameFailed) && shouldFetchMyGames ? normalizedOwner : undefined,
     limit: (isSlotMode || metagameFailed) && shouldFetchMyGames ? 100 : 0,
     forceRecs: metagameFailed, // Force RECS query on sepolia/mainnet when metagame fails
   });


### PR DESCRIPTION
## Summary

Fixes the "My Games" and "Leaderboard" queries to work without the metagame-sdk relayer infrastructure.

### Problem
The metagame-sdk expects Budokan/Denshokan relayer tables (`relayer_0_0_1-TokenMetadataUpdate`, `relayer_0_0_1-OwnersUpdate`, etc.) that don't exist in our Torii instance. Our Torii only indexes our game's models (`zkube_budo_v1_2_0-*`), causing metagame-sdk SQL queries to return empty results.

### Solution
Updated the fallback hooks to query Torii's native GraphQL API for ERC721 token data:

- **`useGameTokensSlot.ts`**: Now queries `tokenBalances` GraphQL endpoint for owner filtering, then matches with Game model data from RECS
- **`useLeaderboardSlot.ts`**: Now queries `tokenTransfers` GraphQL endpoint (mints from 0x0) to get token ownership and player names

### Changes
- `useGameTokensSlot.ts`: Query Torii GraphQL `tokenBalances` for ERC721 ownership
- `useLeaderboardSlot.ts`: Query Torii GraphQL `tokenTransfers` for player data
- Parse player names from ERC721 token metadata
- Fall back to Cartridge `lookupAddresses` for username resolution