### PR TITLE
feat: Add refresh_metadata function to fix stale NFT images

### DIFF
--- a/client-budokan/src/dojo/contractSystems.ts
+++ b/client-budokan/src/dojo/contractSystems.ts
@@ -23,6 +23,10 @@ export interface Surrender extends Signer {
   game_id: number;
 }
 
+export interface RefreshMetadata extends Signer {
+  game_id: number;
+}
+
 export interface Create extends Signer {
   token_id: number;
   selected_bonuses: number[]; // [] uses default Hammer/Wave/Totem
@@ -184,6 +188,21 @@ export function setupWorld(config: Config) {
       }
     };
 
+    const refresh_metadata = async ({ account, game_id }: RefreshMetadata) => {
+      try {
+        return await account.execute([
+          {
+            contractAddress: contract.address,
+            entrypoint: "refresh_metadata",
+            calldata: [game_id],
+          },
+        ]);
+      } catch (error) {
+        console.error("Error executing refresh_metadata:", error);
+        throw error;
+      }
+    };
+
     const move = async ({
       account,
       game_id,
@@ -233,6 +252,7 @@ export function setupWorld(config: Config) {
       free_mint,
       create,
       surrender,
+      refresh_metadata,
       move,
       bonus,
     };

--- a/client-budokan/src/dojo/systems.ts
+++ b/client-budokan/src/dojo/systems.ts
@@ -216,6 +216,14 @@ export function systems({ client }: { client: IWorld }) {
     );
   };
 
+  const refreshMetadata = async ({ account, ...props }: SystemTypes.RefreshMetadata) => {
+    await handleTransaction(
+      account,
+      () => client.game.refresh_metadata({ account, ...props }),
+      "NFT metadata refreshed."
+    );
+  };
+
   const move = async ({ account, ...props }: SystemTypes.Move) => {
     console.log("move", account, props);
     const setMoveComplete = useMoveStore.getState().setMoveComplete; //  Zustand
@@ -322,6 +330,7 @@ export function systems({ client }: { client: IWorld }) {
     freeMint,
     create,
     surrender,
+    refreshMetadata,
     move,
     applyBonus,
     // in-game shop

--- a/client-budokan/src/ui/screens/Home.tsx
+++ b/client-budokan/src/ui/screens/Home.tsx
@@ -18,7 +18,9 @@ import {
   faFire,
   faStar,
   faRotateRight,
+  faSync,
 } from "@fortawesome/free-solid-svg-icons";
+import { useDojo } from "@/dojo/useDojo";
 import MaxComboIcon from "../components/MaxComboIcon";
 import GameBoard from "../components/GameBoard";
 import { useGrid } from "@/hooks/useGrid";
@@ -109,7 +111,9 @@ const getAttributeValue = (
 export const Home = () => {
   useViewport();
   const { account } = useAccountCustom();
+  const { setup: { systemCalls } } = useDojo();
   const [animationDone, setAnimationDone] = useState(false);
+  const [refreshingGames, setRefreshingGames] = useState<Set<number>>(new Set());
 
   const { theme, themeTemplate } = useTheme();
   const imgAssets = ImageAssets(themeTemplate);
@@ -240,6 +244,20 @@ export const Home = () => {
     return value.toString();
   };
 
+  const handleRefreshMetadata = async (tokenId: number) => {
+    if (!account) return;
+    setRefreshingGames(prev => new Set(prev).add(tokenId));
+    try {
+      await systemCalls.refreshMetadata({ account, game_id: tokenId });
+    } finally {
+      setRefreshingGames(prev => {
+        const next = new Set(prev);
+        next.delete(tokenId);
+        return next;
+      });
+    }
+  };
+
   const renderMyGamesTable = (games: PlayerGameRow[]) => {
     if (!isMdOrLarger) {
       return (
@@ -254,19 +272,42 @@ export const Home = () => {
                   <span className="text-slate-400 mr-1">#{game.tokenId}</span>
                   {game.name}
                 </div>
-                {!game.gameOver ? (
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    onClick={() => navigate(`/play/${game.tokenId}`)}
-                  >
-                    Resume
-                  </Button>
-                ) : (
-                  <span className="text-xs font-semibold uppercase tracking-wide text-slate-300">
-                    Finished
-                  </span>
-                )}
+                <div className="flex items-center gap-2">
+                  <TooltipProvider delayDuration={0}>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Button
+                          size="sm"
+                          variant="ghost"
+                          onClick={() => handleRefreshMetadata(game.tokenId)}
+                          disabled={refreshingGames.has(game.tokenId)}
+                          className="h-8 w-8 p-0"
+                        >
+                          <FontAwesomeIcon 
+                            icon={faSync} 
+                            className={refreshingGames.has(game.tokenId) ? "animate-spin" : ""}
+                          />
+                        </Button>
+                      </TooltipTrigger>
+                      <TooltipContent side="bottom">
+                        <p>Refresh NFT Image</p>
+                      </TooltipContent>
+                    </Tooltip>
+                  </TooltipProvider>
+                  {!game.gameOver ? (
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={() => navigate(`/play/${game.tokenId}`)}
+                    >
+                      Resume
+                    </Button>
+                  ) : (
+                    <span className="text-xs font-semibold uppercase tracking-wide text-slate-300">
+                      Finished
+                    </span>
+                  )}
+                </div>
               </div>
               <div className="mt-3 grid grid-cols-3 gap-3 text-sm text-slate-200">
                 <div>
@@ -405,19 +446,42 @@ export const Home = () => {
                         </TooltipProvider>
                       </TableCell>
                     <TableCell>
-                      {!game.gameOver ? (
-                        <Button
-                          size="sm"
-                          variant="outline"
-                          onClick={() => navigate(`/play/${game.tokenId}`)}
-                        >
-                          Play
-                        </Button>
-                      ) : (
-                        <span className="text-sm text-muted-foreground">
-                          Completed
-                        </span>
-                      )}
+                      <div className="flex items-center gap-2">
+                        <TooltipProvider delayDuration={0}>
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <Button
+                                size="sm"
+                                variant="ghost"
+                                onClick={() => handleRefreshMetadata(game.tokenId)}
+                                disabled={refreshingGames.has(game.tokenId)}
+                                className="h-8 w-8 p-0"
+                              >
+                                <FontAwesomeIcon 
+                                  icon={faSync} 
+                                  className={refreshingGames.has(game.tokenId) ? "animate-spin" : ""}
+                                />
+                              </Button>
+                            </TooltipTrigger>
+                            <TooltipContent side="bottom">
+                              <p>Refresh NFT Image</p>
+                            </TooltipContent>
+                          </Tooltip>
+                        </TooltipProvider>
+                        {!game.gameOver ? (
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            onClick={() => navigate(`/play/${game.tokenId}`)}
+                          >
+                            Play
+                          </Button>
+                        ) : (
+                          <span className="text-sm text-muted-foreground">
+                            Completed
+                          </span>
+                        )}
+                      </div>
                     </TableCell>
                   </TableRow>
                 ))}

--- a/contracts/manifest_sepolia.json
+++ b/contracts/manifest_sepolia.json
@@ -82,7 +82,7 @@
     },
     {
       "address": "0x3aeb60202020a2b6a7b0ba3bbafc7f667836c2c89e07aac2a894c2b9b449d8f",
-      "class_hash": "0x1b1f3dd6c7d00db7e256d533a4f873ca5d9cd752f8f24ad3c7674455ac617d",
+      "class_hash": "0x29b852758cfbff15754faa92a2ad9d1891de0350b86d20a09d12e9ce20e04ab",
       "init_calldata": [
         "0x066bE88C48b0D71d1Bded275e211C2dDe1EF1c078Fd57ece1313f130Bbc5b859",
         "0x045a74be8647d39de23b2b73e98862f6b663164fd8f985cfd80eaa6be495f8ba",
@@ -95,6 +95,7 @@
         "dojo_init",
         "create",
         "surrender",
+        "refresh_metadata",
         "upgrade"
       ]
     },
@@ -140,7 +141,7 @@
     },
     {
       "address": "0x51b40b705f5ed82d309b000ca6b0c31bae530ae4e0864cc9ebe78a7bb3f9a0e",
-      "class_hash": "0x4ba9c3a568e4a1c6d75692ac56d859d35f39bc900f911add1ee4a1ac2d3fb61",
+      "class_hash": "0x637d8cf37b1a154a9b063f6b9fd277e12a3d49d81f6bcc25d079708b8cbfe4e",
       "init_calldata": [],
       "tag": "zkube_budo_v1_2_0-quest_system",
       "selector": "0x436c9e32f41800b6e41f7a2132179a85ad4fbbcd73cf2db6bcb4b65fd2071e",
@@ -151,12 +152,13 @@
         "on_quest_claim",
         "claim",
         "progress",
+        "reinitialize_quests",
         "upgrade"
       ]
     },
     {
       "address": "0x5b02300e7fc8b04e492ce2f7406347369b868f0b1ff9f552f2e8c03e2f0450c",
-      "class_hash": "0x794273ece4fd58d2db65b7e0666bb2f9a31d9f7ebf598388d18323c49f0b45c",
+      "class_hash": "0x362e90bebd91e1081960c030807707103f9619bb30e69f9f0210f8aad783296",
       "init_calldata": [],
       "tag": "zkube_budo_v1_2_0-renderer_systems",
       "selector": "0x35d5ac8794cc2cf3e12c42d4ac579e7a5dc26a70c26e32c599915d2d39586cf",
@@ -6973,6 +6975,18 @@
         },
         {
           "type": "function",
+          "name": "refresh_metadata",
+          "inputs": [
+            {
+              "name": "game_id",
+              "type": "core::integer::u64"
+            }
+          ],
+          "outputs": [],
+          "state_mutability": "external"
+        },
+        {
+          "type": "function",
           "name": "get_player_name",
           "inputs": [
             {
@@ -7330,6 +7344,13 @@
               "type": "core::integer::u32"
             }
           ],
+          "outputs": [],
+          "state_mutability": "external"
+        },
+        {
+          "type": "function",
+          "name": "reinitialize_quests",
+          "inputs": [],
           "outputs": [],
           "state_mutability": "external"
         }

--- a/contracts/manifest_sepolia.json
+++ b/contracts/manifest_sepolia.json
@@ -82,7 +82,7 @@
     },
     {
       "address": "0x3aeb60202020a2b6a7b0ba3bbafc7f667836c2c89e07aac2a894c2b9b449d8f",
-      "class_hash": "0x29b852758cfbff15754faa92a2ad9d1891de0350b86d20a09d12e9ce20e04ab",
+      "class_hash": "0x602b7b6c76dae13a222ab78b818c8f9db76396ac5db889a1596171a3812da5e",
       "init_calldata": [
         "0x066bE88C48b0D71d1Bded275e211C2dDe1EF1c078Fd57ece1313f130Bbc5b859",
         "0x045a74be8647d39de23b2b73e98862f6b663164fd8f985cfd80eaa6be495f8ba",

--- a/contracts/src/systems/game.cairo
+++ b/contracts/src/systems/game.cairo
@@ -50,6 +50,7 @@ mod game_system {
     use game_components_minigame::interface::{IMinigameTokenData};
     use game_components_minigame::libs::{
         assert_token_ownership, get_player_name as get_token_player_name, post_action, pre_action,
+        require_owned_token,
     };
     use game_components_minigame::minigame::MinigameComponent;
     use game_components_token::core::interface::{
@@ -359,10 +360,11 @@ mod game_system {
         fn refresh_metadata(ref self: ContractState, game_id: u64) {
             // Anyone can call this to trigger a MetadataUpdate event
             // Useful when wallet/marketplace has cached stale NFT image
+            // Works for both active AND completed games (unlike pre_action which checks playability)
             let token_address = self.token_address();
             
-            // Verify token exists (pre_action checks this)
-            pre_action(token_address, game_id);
+            // Only verify token exists (don't check playability - completed games should work too)
+            require_owned_token(token_address, game_id);
             
             // Trigger MetadataUpdate event by calling update_game on the token
             post_action(token_address, game_id);

--- a/contracts/src/systems/game.cairo
+++ b/contracts/src/systems/game.cairo
@@ -9,6 +9,9 @@ pub trait IGameSystem<T> {
     fn create(ref self: T, game_id: u64, selected_bonuses: Span<u8>, cubes_amount: u16);
     /// Surrender the current run (game over)
     fn surrender(ref self: T, game_id: u64);
+    /// Refresh NFT metadata by triggering MetadataUpdate event
+    /// Call this if wallet/marketplace shows stale NFT image
+    fn refresh_metadata(ref self: T, game_id: u64);
     /// Get player name from token
     fn get_player_name(self: @T, game_id: u64) -> felt252;
     /// Get current level score
@@ -305,8 +308,6 @@ mod game_system {
             // Only counts for default settings games
             libs.track_quest(player, grinder::Grinder::identifier(), 1, settings.settings_id);
 
-            post_action(token_address, game_id);
-
             // Emit start game event
             world.emit_event(@StartGame { player, timestamp, game_id });
 
@@ -322,6 +323,10 @@ mod game_system {
                 game.set_run_data(run_data);
                 world.write_model(@game);
             }
+
+            // Call post_action AFTER all state modifications are complete
+            // This triggers MetadataUpdate event with the correct game state
+            post_action(token_address, game_id);
         }
 
         fn surrender(ref self: ContractState, game_id: u64) {
@@ -348,6 +353,18 @@ mod game_system {
             let player = get_caller_address();
             game_over::handle_game_over(ref world, game, player);
 
+            post_action(token_address, game_id);
+        }
+
+        fn refresh_metadata(ref self: ContractState, game_id: u64) {
+            // Anyone can call this to trigger a MetadataUpdate event
+            // Useful when wallet/marketplace has cached stale NFT image
+            let token_address = self.token_address();
+            
+            // Verify token exists (pre_action checks this)
+            pre_action(token_address, game_id);
+            
+            // Trigger MetadataUpdate event by calling update_game on the token
             post_action(token_address, game_id);
         }
 

--- a/manifest_sepolia.json
+++ b/manifest_sepolia.json
@@ -82,7 +82,7 @@
     },
     {
       "address": "0x3aeb60202020a2b6a7b0ba3bbafc7f667836c2c89e07aac2a894c2b9b449d8f",
-      "class_hash": "0x1b1f3dd6c7d00db7e256d533a4f873ca5d9cd752f8f24ad3c7674455ac617d",
+      "class_hash": "0x29b852758cfbff15754faa92a2ad9d1891de0350b86d20a09d12e9ce20e04ab",
       "init_calldata": [
         "0x066bE88C48b0D71d1Bded275e211C2dDe1EF1c078Fd57ece1313f130Bbc5b859",
         "0x045a74be8647d39de23b2b73e98862f6b663164fd8f985cfd80eaa6be495f8ba",
@@ -95,6 +95,7 @@
         "dojo_init",
         "create",
         "surrender",
+        "refresh_metadata",
         "upgrade"
       ]
     },
@@ -6963,6 +6964,18 @@
         {
           "type": "function",
           "name": "surrender",
+          "inputs": [
+            {
+              "name": "game_id",
+              "type": "core::integer::u64"
+            }
+          ],
+          "outputs": [],
+          "state_mutability": "external"
+        },
+        {
+          "type": "function",
+          "name": "refresh_metadata",
           "inputs": [
             {
               "name": "game_id",

--- a/manifest_sepolia.json
+++ b/manifest_sepolia.json
@@ -82,7 +82,7 @@
     },
     {
       "address": "0x3aeb60202020a2b6a7b0ba3bbafc7f667836c2c89e07aac2a894c2b9b449d8f",
-      "class_hash": "0x29b852758cfbff15754faa92a2ad9d1891de0350b86d20a09d12e9ce20e04ab",
+      "class_hash": "0x602b7b6c76dae13a222ab78b818c8f9db76396ac5db889a1596171a3812da5e",
       "init_calldata": [
         "0x066bE88C48b0D71d1Bded275e211C2dDe1EF1c078Fd57ece1313f130Bbc5b859",
         "0x045a74be8647d39de23b2b73e98862f6b663164fd8f985cfd80eaa6be495f8ba",


### PR DESCRIPTION
## Summary
- Add `refresh_metadata()` contract function to trigger NFT MetadataUpdate events
- Fix `create()` post_action ordering bug that caused incorrect initial NFT state
- Add "Refresh NFT" button to My Games table in frontend

## Problem
NFT images in Cartridge Controller were showing stale/cached data (e.g., "Game not started" even for completed games). Investigation confirmed the on-chain SVG data is correct, but wallets cache the image.

## Changes

### Contracts
- **`game_system.cairo`**: 
  - Add `refresh_metadata(game_id)` function that triggers MetadataUpdate event
  - Works for both active AND completed games (uses `require_owned_token` not `pre_action`)
  - Fix `create()` to call `post_action` AFTER level/grid initialization

### Frontend
- **`contractSystems.ts`**: Add `refresh_metadata` call
- **`systems.ts`**: Add `refreshMetadata` wrapper
- **`Home.tsx`**: Add refresh button (🔄) in My Games table
  - Shows spinning animation while refreshing
  - Tooltip: "Refresh NFT Image"
  - Works on mobile and desktop views

## Testing
- Deployed to Sepolia ✅
- Tested refresh on completed game #7 ✅

## Commits
- `cd0ee24` - Fix create() post_action ordering and add refresh_metadata()
- `74e2a66` - Add frontend button and system calls
- `42e448a` - Fix to allow refresh on completed games