### PR TITLE
fix: Cartridge Controller integration, UI polish, and network fixes

### DIFF
--- a/client-budokan/src/App.tsx
+++ b/client-budokan/src/App.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react";
 import { Toaster } from "./ui/elements/sonner";
 import { TooltipProvider } from "@/ui/elements/tooltip";
 import PageNavigator from "@/ui/navigation/PageNavigator";
@@ -37,10 +38,33 @@ const CurrentPage: React.FC = () => {
   return <>{pageComponents[currentPage]}</>;
 };
 
-export default function App() {
-  const { isReconnecting } = useAccount();
+// starknet-react's isReconnecting is never set to true — auto-connect is fire-and-forget.
+// We gate on lastUsedConnector in localStorage to hold the loading screen until connected or timeout.
+function useAutoConnectGate(): boolean {
+  const { status } = useAccount();
+  const [waiting, setWaiting] = useState(
+    () => localStorage.getItem("lastUsedConnector") !== null,
+  );
 
-  if (isReconnecting) return <Loading />;
+  useEffect(() => {
+    if (!waiting) return;
+
+    if (status === "connected") {
+      setWaiting(false);
+      return;
+    }
+
+    const timer = setTimeout(() => setWaiting(false), 3000);
+    return () => clearTimeout(timer);
+  }, [waiting, status]);
+
+  return waiting;
+}
+
+export default function App() {
+  const waitingForAutoConnect = useAutoConnectGate();
+
+  if (waitingForAutoConnect) return <Loading />;
 
   return (
     <TooltipProvider>

--- a/client-budokan/src/App.tsx
+++ b/client-budokan/src/App.tsx
@@ -4,6 +4,8 @@ import PageNavigator from "@/ui/navigation/PageNavigator";
 import { useNavigationStore } from "@/stores/navigationStore";
 import type { PageId } from "@/stores/navigationStore";
 import { getToastPlacement } from "@/utils/toast";
+import { useAccount } from "@starknet-react/core";
+import { Loading } from "@/ui/screens/Loading";
 import HomePage from "@/ui/pages/HomePage";
 import LoadoutPage from "@/ui/pages/LoadoutPage";
 import PlayScreen from "@/ui/pages/PlayScreen";
@@ -36,6 +38,10 @@ const CurrentPage: React.FC = () => {
 };
 
 export default function App() {
+  const { isReconnecting } = useAccount();
+
+  if (isReconnecting) return <Loading />;
+
   return (
     <TooltipProvider>
       <PageNavigator>

--- a/client-budokan/src/hooks/useCubeBalance.tsx
+++ b/client-budokan/src/hooks/useCubeBalance.tsx
@@ -10,6 +10,12 @@ const normalizeAddress = (addr: string): string => {
   return "0x" + addr.slice(2).replace(/^0+/, "").toLowerCase();
 };
 
+const padAddress = (addr: string): string => {
+  if (!addr) return addr;
+  const hex = addr.startsWith("0x") ? addr.slice(2) : addr;
+  return `0x${hex.padStart(64, "0")}`;
+};
+
 interface CubeBalanceResult {
   cubeBalance: bigint;
   isLoading: boolean;
@@ -42,9 +48,12 @@ export const useCubeBalance = (): CubeBalanceResult => {
     try {
       setLoading(true);
 
+      const paddedContract = padAddress(VITE_PUBLIC_CUBE_TOKEN_ADDRESS);
+      const paddedAccount = padAddress(address);
+
       const result = await toriiClient.getTokenBalances({
-        contract_addresses: [VITE_PUBLIC_CUBE_TOKEN_ADDRESS],
-        account_addresses: [address],
+        contract_addresses: [paddedContract],
+        account_addresses: [paddedAccount],
         token_ids: [],
         pagination: {
           limit: 10,
@@ -79,8 +88,8 @@ export const useCubeBalance = (): CubeBalanceResult => {
     const subscribe = async () => {
       try {
         const subscription = await toriiClient.onTokenBalanceUpdated(
-          [VITE_PUBLIC_CUBE_TOKEN_ADDRESS],
-          [address],
+          [padAddress(VITE_PUBLIC_CUBE_TOKEN_ADDRESS)],
+          [padAddress(address)],
           [],
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (update: any) => {

--- a/client-budokan/src/ui/elements/sonner.tsx
+++ b/client-budokan/src/ui/elements/sonner.tsx
@@ -10,6 +10,7 @@ const Toaster = ({ ...props }: ToasterProps) => {
     <Sonner
       theme={theme as ToasterProps["theme"]}
       className="toaster group"
+      duration={2000}
       toastOptions={{
         classNames: {
           toast:

--- a/client-budokan/src/ui/pages/HomePage.tsx
+++ b/client-budokan/src/ui/pages/HomePage.tsx
@@ -29,7 +29,7 @@ const HomePage: React.FC = () => {
   useViewport();
 
   const { account } = useAccountCustom();
-  const { connector, isReconnecting } = useAccount();
+  const { connector } = useAccount();
   const { username } = useControllerUsername();
   const { themeTemplate, setThemeTemplate } = useTheme();
   const { setMusicPlaylist } = useMusicPlayer();
@@ -109,7 +109,7 @@ const HomePage: React.FC = () => {
         )}
 
         <div className="flex flex-col items-center gap-3 w-full mt-2">
-          {isReconnecting ? null : !account ? (
+          {!account ? (
             <Connect />
           ) : (
             <>

--- a/client-budokan/src/ui/pages/HomePage.tsx
+++ b/client-budokan/src/ui/pages/HomePage.tsx
@@ -29,7 +29,7 @@ const HomePage: React.FC = () => {
   useViewport();
 
   const { account } = useAccountCustom();
-  const { connector } = useAccount();
+  const { connector, isReconnecting } = useAccount();
   const { username } = useControllerUsername();
   const { themeTemplate, setThemeTemplate } = useTheme();
   const { setMusicPlaylist } = useMusicPlayer();
@@ -109,7 +109,7 @@ const HomePage: React.FC = () => {
         )}
 
         <div className="flex flex-col items-center gap-3 w-full mt-2">
-          {!account ? (
+          {isReconnecting ? null : !account ? (
             <Connect />
           ) : (
             <>

--- a/client-budokan/src/ui/pages/LoadoutPage.tsx
+++ b/client-budokan/src/ui/pages/LoadoutPage.tsx
@@ -228,7 +228,7 @@ const LoadoutPage: React.FC = () => {
         type: "success",
       });
 
-      navigate("play", gameId);
+      navigate("map", gameId);
     } catch (error) {
       console.error("Error starting game:", error);
       showToast({

--- a/client-budokan/src/utils/toast.ts
+++ b/client-budokan/src/utils/toast.ts
@@ -115,7 +115,7 @@ export const showToast = ({
 
   switch (type) {
     case "loading":
-      toast.loading(message, toastOptions);
+      toast.loading(message, { ...toastOptions, duration: toastOptions.duration ?? 5000 });
       break;
     case "success":
       toast.success(message, toastOptions);


### PR DESCRIPTION
## Summary

- **Always use Cartridge Controller** on all networks (slot, sepolia, mainnet) — removed burner account bypass and `isSlotMode`/`forceRecs` guards
- **Fix login flash** — replaced broken `isReconnecting` (never set to true in starknet-react) with `useAutoConnectGate` that gates on `lastUsedConnector` in localStorage
- **Fix game fetching on Sepolia** — corrected Torii URL, fixed MyGamesPage missing data fetch, normalized entity IDs
- **Fix cube balance showing 0** — pad 65-char addresses to 66-char for Torii's `getTokenBalances`
- **Fix stale WASM sessions** — clear IndexedDB on deploy-type switch to purge cached Controller RPC endpoints
- **Wire profile/trophies buttons** to `controller.openProfile()`, show username in TopBar
- **Add claimable quest badge** (red count) on quest button
- **New game navigates to map** instead of directly to play screen
- **Achievement points** capped at 100 per trophy, deployed to sepolia

## Changed files (27)
- `client-budokan/src/App.tsx` — Auto-connect loading gate
- `client-budokan/src/cartridgeConnector.tsx` — Always create connector, IndexedDB clearing
- `client-budokan/src/hooks/useAccountCustom.tsx` — Simplified to always use controller
- `client-budokan/src/hooks/useCubeBalance.tsx` — Address padding fix
- `client-budokan/src/hooks/useGameTokensSlot.ts` — Removed isSlotMode guard
- `client-budokan/src/hooks/useLeaderboardSlot.ts` — Removed isSlotMode guard
- `client-budokan/src/ui/navigation/TopBar.tsx` — Username + quest badge
- `client-budokan/src/ui/pages/HomePage.tsx` — Profile/trophies handlers
- `client-budokan/src/ui/pages/LoadoutPage.tsx` — Navigate to map after game creation
- `client-budokan/src/ui/pages/MyGamesPage.tsx` — Fixed game fetching
- `client-budokan/.env.sepolia` — Corrected Torii URL
- `contracts/` — Achievement point caps, sepolia manifests, deploy scripts