### PR TITLE
UI polish: skill tree, map rewrite, draft redesign, panel contrast

### DIFF
--- a/client-budokan/src/dojo/game/constants.ts
+++ b/client-budokan/src/dojo/game/constants.ts
@@ -9,3 +9,16 @@ export const BLOCK_SIZE = 8;
 export const BLOCK_BIT_COUNT = 3;
 export const ROW_SIZE = 16777216;
 export const ROW_BIT_COUNT = 24;
+
+// Skill system (mirrors contracts/src/helpers/packing.cairo & skill_tree.cairo)
+export const MAX_LOADOUT_SLOTS = 3;
+export const TOTAL_SKILLS = 15;
+export const MAX_SKILL_LEVEL = 9;
+export const BRANCH_POINT_LEVEL = 4;
+export const BRANCH_SPLIT_LEVEL = 5;
+
+// Level system (mirrors contracts/src/helpers/level.cairo)
+export const LEVEL_CAP = 50;
+export const BOSS_INTERVAL = 10;
+export const BOSS_LEVELS = [10, 20, 30, 40, 50] as const;
+export const PRE_BOSS_LEVELS = [9, 19, 29, 39, 49] as const;

--- a/client-budokan/src/dojo/game/helpers/runDataPacking.ts
+++ b/client-budokan/src/dojo/game/helpers/runDataPacking.ts
@@ -1,3 +1,4 @@
+import { BOSS_INTERVAL } from "@/dojo/game/constants";
 /**
  * Bit-packing helpers for efficient storage
  * Mirrors the Cairo packing.cairo implementation
@@ -196,7 +197,7 @@ export function createInitialRunData(): RunData {
  * Check if the current level is a boss level (10, 20, 30, 40, 50)
  */
 export function isBossLevel(level: number): boolean {
-  return level > 0 && level % 10 === 0;
+  return level > 0 && level % BOSS_INTERVAL === 0;
 }
 
 /**

--- a/client-budokan/src/dojo/game/types/level.ts
+++ b/client-budokan/src/dojo/game/types/level.ts
@@ -14,6 +14,7 @@
 import { hash } from "starknet";
 import { Difficulty, DifficultyType } from "./difficulty";
 import { Constraint } from "./constraint";
+import { BOSS_LEVELS } from "@/dojo/game/constants";
 
 /**
  * GameSettings interface matching the Cairo contract
@@ -683,7 +684,7 @@ function maybeGenerateSecondaryConstraint(
  * Check if a level is a boss level (10, 20, 30, 40, 50)
  */
 function isBossLevel(level: number): boolean {
-  return [10, 20, 30, 40, 50].includes(level);
+  return BOSS_LEVELS.includes(level as typeof BOSS_LEVELS[number]);
 }
 
 /**

--- a/client-budokan/src/hooks/useMapLayout.ts
+++ b/client-budokan/src/hooks/useMapLayout.ts
@@ -90,11 +90,20 @@ function buildZoneLayout(
     const isFirst = i === 0;
     const isLast = i === lastNode;
 
-    // Boss, entry-draft, and pre-boss nodes get centered
-    // Pre-boss centered to avoid tangling with the larger boss node
-    if (isFirst || isLast || i === lastNode - 1) {
+    // Boss and entry-draft get centered
+    if (isFirst || isLast) {
       points.push({ x: 0.5, y });
       lane = 1; // reset to center for next alternation
+      continue;
+    }
+
+    // Pre-boss node: force to an outer lane (opposite of previous) so it
+    // doesn't tangle with the large centered boss above it.
+    if (i === lastNode - 1) {
+      lane = lane === 0 ? 2 : 0; // flip to opposite outer lane
+      const xJitter = (hashToUnit(seed, zoneIndex, i, 202) - 0.5) * X_JITTER;
+      const x = clamp(LANES[lane] + xJitter, 0.14, 0.86);
+      points.push({ x, y });
       continue;
     }
 

--- a/client-budokan/src/hooks/useMapLayout.ts
+++ b/client-budokan/src/hooks/useMapLayout.ts
@@ -90,8 +90,9 @@ function buildZoneLayout(
     const isFirst = i === 0;
     const isLast = i === lastNode;
 
-    // Boss and entry-draft nodes get centered
-    if (isFirst || isLast) {
+    // Boss, entry-draft, and pre-boss nodes get centered
+    // Pre-boss centered to avoid tangling with the larger boss node
+    if (isFirst || isLast || i === lastNode - 1) {
       points.push({ x: 0.5, y });
       lane = 1; // reset to center for next alternation
       continue;

--- a/client-budokan/src/ui/components/GameOverDialog.tsx
+++ b/client-budokan/src/ui/components/GameOverDialog.tsx
@@ -5,6 +5,7 @@ import { motion, type Variants } from "motion/react";
 import { usePlayerMeta } from "@/hooks/usePlayerMeta";
 import { Flame, Gem, Layers, RotateCw, Trophy } from "lucide-react";
 import CubeIcon from "@/ui/components/CubeIcon";
+import { BOSS_LEVELS, PRE_BOSS_LEVELS, LEVEL_CAP } from "@/dojo/game/constants";
 
 interface GameOverDialogProps {
   isOpen: boolean;
@@ -12,7 +13,6 @@ interface GameOverDialogProps {
   game: Game;
 }
 
-const BOSS_LEVELS = [10, 20, 30, 40, 50];
 
 const GameOverDialog: React.FC<GameOverDialogProps> = ({
   isOpen,
@@ -38,8 +38,8 @@ const GameOverDialog: React.FC<GameOverDialogProps> = ({
   // Contextual subtitle based on performance
   const subtitle = useMemo(() => {
     if (isNewBestLevel && game.level > 1) return "New personal best!";
-    if ([9, 19, 29, 39, 49].includes(game.level)) return "So close to the boss...";
-    if (BOSS_LEVELS.includes(game.level) && game.level < 50) return "Fell to the boss...";
+    if ((PRE_BOSS_LEVELS as readonly number[]).includes(game.level)) return "So close to the boss...";
+    if (BOSS_LEVELS.includes(game.level as typeof BOSS_LEVELS[number]) && game.level < LEVEL_CAP) return "Fell to the boss...";
     if (game.level >= 40) return "Legendary run!";
     if (game.level >= 25) return "Incredible run!";
     if (game.level >= 10) return "Nice run!";
@@ -50,8 +50,8 @@ const GameOverDialog: React.FC<GameOverDialogProps> = ({
   // Subtitle color based on sentiment
   const subtitleColor = useMemo(() => {
     if (isNewBestLevel && game.level > 1) return "text-yellow-400";
-    if ([9, 19, 29, 39, 49].includes(game.level)) return "text-orange-400";
-    if (BOSS_LEVELS.includes(game.level)) return "text-red-400";
+    if ((PRE_BOSS_LEVELS as readonly number[]).includes(game.level)) return "text-orange-400";
+    if (BOSS_LEVELS.includes(game.level as typeof BOSS_LEVELS[number])) return "text-red-400";
     if (game.level >= 25) return "text-purple-400";
     if (game.level >= 10) return "text-cyan-400";
     if (game.level >= 5) return "text-slate-300";
@@ -71,9 +71,9 @@ const GameOverDialog: React.FC<GameOverDialogProps> = ({
       opener = `I just crushed Level ${level} on @zkube_game!`;
     } else if (level >= 25) {
       opener = `Level ${level} down on @zkube_game!`;
-    } else if (BOSS_LEVELS.includes(level)) {
+    } else if (BOSS_LEVELS.includes(level as typeof BOSS_LEVELS[number])) {
       opener = `Just beat the Level ${level} boss on @zkube_game!`;
-    } else if ([9, 19, 29, 39, 49].includes(level)) {
+    } else if ((PRE_BOSS_LEVELS as readonly number[]).includes(level)) {
       opener = `So close! Reached Level ${level} on @zkube_game`;
     } else if (level >= 10) {
       opener = `Made it to Level ${level} on @zkube_game!`;

--- a/client-budokan/src/ui/components/LevelCompleteDialog.tsx
+++ b/client-budokan/src/ui/components/LevelCompleteDialog.tsx
@@ -7,6 +7,8 @@ import { Check, Trophy } from "lucide-react";
 import type { GameLevelData } from "@/hooks/useGameLevel";
 import { useMusicPlayer } from "@/contexts/hooks";
 import CubeIcon from "@/ui/components/CubeIcon";
+import { BOSS_INTERVAL } from "@/dojo/game/constants";
+import { isBossLevel as checkBossLevel } from "@/dojo/game/helpers/runDataPacking";
 
 interface LevelCompleteDialogProps {
   isOpen: boolean;
@@ -120,8 +122,8 @@ const LevelCompleteDialog: React.FC<LevelCompleteDialogProps> = ({
   const totalLevelCubes = totalCubes - prevTotalCubes;
 
   // Boss level bonus (levels 10, 20, 30, 40, 50)
-  const isBossLevel = [10, 20, 30, 40, 50].includes(level);
-  const bossTier = Math.floor(level / 10);
+  const isBossLevel = checkBossLevel(level);
+  const bossTier = Math.floor(level / BOSS_INTERVAL);
   const bossBonus = isBossLevel ? 10 * bossTier * bossTier : 0;
 
   const extraRewardCubes = Math.max(0, totalLevelCubes - baseCubesEarned - bossBonus);

--- a/client-budokan/src/ui/components/Shop/BonusSelectionDialog.tsx
+++ b/client-budokan/src/ui/components/Shop/BonusSelectionDialog.tsx
@@ -9,6 +9,7 @@ import {
   bonusTypeToContractValue,
 } from "@/dojo/game/types/bonus";
 import { useMusicPlayer } from "@/contexts/hooks";
+import { MAX_LOADOUT_SLOTS } from "@/dojo/game/constants";
 
 interface BonusSelectionDialogProps {
   isOpen: boolean;
@@ -83,13 +84,13 @@ const BonusSelectionDialog: React.FC<BonusSelectionDialogProps> = ({
       if (prev.includes(type)) {
         return prev.filter((b) => b !== type);
       }
-      if (prev.length >= 3) return prev;
+      if (prev.length >= MAX_LOADOUT_SLOTS) return prev;
       return [...prev, type];
     });
   };
 
   const handleConfirm = () => {
-    if (selected.length !== 3) return;
+    if (selected.length !== MAX_LOADOUT_SLOTS) return;
     const selectedValues = selected.map((type) => bonusTypeToContractValue(type));
     onConfirm(selectedValues);
   };
@@ -144,7 +145,7 @@ const BonusSelectionDialog: React.FC<BonusSelectionDialogProps> = ({
 
         <Button
           onClick={handleConfirm}
-          disabled={selected.length !== 3}
+          disabled={selected.length !== MAX_LOADOUT_SLOTS}
           className="w-full py-3"
         >
           Confirm Selection

--- a/client-budokan/src/ui/pages/DraftPage.tsx
+++ b/client-budokan/src/ui/pages/DraftPage.tsx
@@ -5,6 +5,7 @@ import { useNavigationStore } from "@/stores/navigationStore";
 import { useCubeBalance } from "@/hooks/useCubeBalance";
 import { useGame } from "@/hooks/useGame";
 import { useDraft } from "@/hooks/useDraft";
+import { useSkillTree } from "@/hooks/useSkillTree";
 import { useDojo } from "@/dojo/useDojo";
 import useAccountCustom from "@/hooks/useAccountCustom";
 import { getRerollCost } from "@/dojo/game/helpers/runDataPacking";
@@ -78,6 +79,7 @@ const DraftPage: React.FC = () => {
     gameId: gameId ?? undefined,
     shouldLog: false,
   });
+  const { skillTree } = useSkillTree();
 
   const [isSelecting, setIsSelecting] = useState(false);
   const [isRerolling, setIsRerolling] = useState(false);
@@ -105,8 +107,9 @@ const DraftPage: React.FC = () => {
       const slot = game?.runData.slots.find(
         (entry) => entry.skillId === skillId,
       );
-      const currentLevel = slot?.level ?? 0;
-      const branchId = undefined;
+      const treeInfo = skillTree?.skills[skillId - 1];
+      const currentLevel = slot?.level ?? treeInfo?.level ?? 0;
+      const branchId = treeInfo?.branchId;
       const archetype = getArchetypeForSkill(skillId);
       const nextLevel = isFullLoadout ? currentLevel + 1 : 0;
       return {
@@ -123,7 +126,7 @@ const DraftPage: React.FC = () => {
         ),
       };
     });
-  }, [draftState, game?.runData.slots, isFullLoadout]);
+  }, [draftState, game?.runData.slots, isFullLoadout, skillTree]);
 
   useEffect(() => {
     if (gameId === null) {

--- a/client-budokan/src/ui/pages/DraftPage.tsx
+++ b/client-budokan/src/ui/pages/DraftPage.tsx
@@ -358,7 +358,7 @@ const DraftPage: React.FC = () => {
                 const isBranchPoint = choice.level === 4 && isFullLoadout;
                 const accentCol = choice.archetype?.color ?? "#64748b";
                 const isPassive = choice.skill?.category === "world";
-                const displayLevel = isFullLoadout ? choice.level + 1 : 0;
+                const displayLevel = choice.level + 1;
 
                 return (
                   <motion.article

--- a/client-budokan/src/ui/pages/DraftPage.tsx
+++ b/client-budokan/src/ui/pages/DraftPage.tsx
@@ -119,7 +119,7 @@ const DraftPage: React.FC = () => {
         level: currentLevel,
         branchId,
         archetype,
-        effectDesc: getSkillEffectDescription(
+      effectDesc: getSkillEffectDescription(
           skillId,
           nextLevel,
           branchId,

--- a/client-budokan/src/ui/pages/DraftPage.tsx
+++ b/client-budokan/src/ui/pages/DraftPage.tsx
@@ -111,7 +111,7 @@ const DraftPage: React.FC = () => {
       const currentLevel = slot?.level ?? treeInfo?.level ?? 0;
       const branchId = treeInfo?.branchId;
       const archetype = getArchetypeForSkill(skillId);
-      const nextLevel = isFullLoadout ? currentLevel + 1 : 0;
+      const nextLevel = isFullLoadout ? currentLevel + 1 : currentLevel;
       return {
         slotIndex: index as 0 | 1 | 2,
         skillId,
@@ -121,7 +121,7 @@ const DraftPage: React.FC = () => {
         archetype,
         effectDesc: getSkillEffectDescription(
           skillId,
-          isFullLoadout ? nextLevel : 0,
+          nextLevel,
           branchId,
         ),
       };

--- a/client-budokan/src/ui/pages/DraftPage.tsx
+++ b/client-budokan/src/ui/pages/DraftPage.tsx
@@ -8,7 +8,8 @@ import { useDraft } from "@/hooks/useDraft";
 import { useSkillTree } from "@/hooks/useSkillTree";
 import { useDojo } from "@/dojo/useDojo";
 import useAccountCustom from "@/hooks/useAccountCustom";
-import { getRerollCost } from "@/dojo/game/helpers/runDataPacking";
+import { getRerollCost, isBonusSkill } from "@/dojo/game/helpers/runDataPacking";
+import { MAX_LOADOUT_SLOTS, BRANCH_POINT_LEVEL } from "@/dojo/game/constants";
 import {
   getSkillById,
   getArchetypeForSkill,
@@ -92,12 +93,12 @@ const DraftPage: React.FC = () => {
   const runSlots = useMemo(
     () =>
       game
-        ? game.runData.slots.slice(0, 3).filter((slot) => slot.skillId > 0)
+        ? game.runData.slots.slice(0, MAX_LOADOUT_SLOTS).filter((slot) => slot.skillId > 0)
         : [],
     [game],
   );
 
-  const isFullLoadout = (game?.activeSlotCount ?? runSlots.length) >= 3;
+  const isFullLoadout = (game?.activeSlotCount ?? runSlots.length) >= MAX_LOADOUT_SLOTS;
 
   const cards = useMemo(() => {
     if (!draftState) return [];
@@ -318,7 +319,7 @@ const DraftPage: React.FC = () => {
                             {slot.level + 1}
                           </span>
                           {/* Charges badge */}
-                          {slot.skillId >= 1 && slot.skillId <= 5 && (
+                          {isBonusSkill(slot.skillId) && (
                             <span
                               className={`absolute -top-0.5 -right-0.5 flex h-[16px] w-[16px] items-center justify-center rounded-full text-[8px] font-bold ${
                                 slot.charges > 0
@@ -355,7 +356,7 @@ const DraftPage: React.FC = () => {
                 const skillName = choice.skill?.name?.toLowerCase() ?? "";
                 const tier = getSkillTier(choice.level);
                 const iconPath = getSkillTierIconPath(skillName, tier);
-                const isBranchPoint = choice.level === 4 && isFullLoadout;
+                const isBranchPoint = choice.level === BRANCH_POINT_LEVEL && isFullLoadout;
                 const accentCol = choice.archetype?.color ?? "#64748b";
                 const isPassive = choice.skill?.category === "world";
                 const displayLevel = choice.level + 1;

--- a/client-budokan/src/ui/pages/MapPage.tsx
+++ b/client-budokan/src/ui/pages/MapPage.tsx
@@ -26,14 +26,12 @@ import { useTheme } from "@/ui/elements/theme-provider/hooks";
 import { useMusicPlayer } from "@/contexts/hooks";
 import { useNavigationStore } from "@/stores/navigationStore";
 import {
-  getDraftEventForCompletedLevel,
   getDraftEventForZoneNode,
   getStoredDraftPick,
   isDraftEventCompleted,
 } from "@/utils/draftEvents";
 import PageTopBar from "@/ui/navigation/PageTopBar";
 import LevelPreview from "@/ui/components/map/LevelPreview";
-import LevelCompleteDialog from "@/ui/components/LevelCompleteDialog";
 import ZoneBackground from "@/ui/components/map/ZoneBackground";
 import { Dialog, DialogContent, DialogTitle } from "@/ui/elements/dialog";
 import { Button } from "@/ui/elements/button";
@@ -126,12 +124,6 @@ const MapPage: React.FC = () => {
   );
   const setPendingPreviewLevel = useNavigationStore(
     (state) => state.setPendingPreviewLevel,
-  );
-  const pendingLevelCompletion = useNavigationStore(
-    (state) => state.pendingLevelCompletion,
-  );
-  const setPendingLevelCompletion = useNavigationStore(
-    (state) => state.setPendingLevelCompletion,
   );
   const pendingDraftEvent = useNavigationStore(
     (state) => state.pendingDraftEvent,
@@ -230,10 +222,6 @@ const MapPage: React.FC = () => {
     [mapData.nodes],
   );
 
-  const completionDraftEvent = useMemo(() => {
-    if (!pendingLevelCompletion) return null;
-    return getDraftEventForCompletedLevel(seed, pendingLevelCompletion.level);
-  }, [pendingLevelCompletion, seed]);
 
   /* ---- Swipe handlers (Pointer Events for reliable mobile) ---- */
 
@@ -619,7 +607,7 @@ const MapPage: React.FC = () => {
         </div>
 
         {/* ---- Level preview modal ---- */}
-        {selectedNode && !pendingLevelCompletion && (
+        {selectedNode && (
           <LevelPreview
             node={selectedNode}
             game={game ?? null}
@@ -630,32 +618,6 @@ const MapPage: React.FC = () => {
           />
         )}
 
-        {/* ---- Level complete overlay ---- */}
-        {pendingLevelCompletion && (
-          <LevelCompleteDialog
-            isOpen={true}
-            onClose={() => {
-              const completedLevel = pendingLevelCompletion.level;
-
-              setPendingLevelCompletion(null);
-
-              if (completionDraftEvent) {
-                setPendingDraftEvent(completionDraftEvent);
-                navigate("draft", gameId ?? undefined);
-              } else {
-                setPendingPreviewLevel(completedLevel + 1);
-              }
-            }}
-            level={pendingLevelCompletion.level}
-            levelMoves={pendingLevelCompletion.levelMoves}
-            prevTotalCubes={pendingLevelCompletion.prevTotalCubes}
-            totalCubes={pendingLevelCompletion.totalCubes}
-            prevTotalScore={pendingLevelCompletion.prevTotalScore}
-            totalScore={pendingLevelCompletion.totalScore}
-            gameLevel={pendingLevelCompletion.gameLevel}
-            draftWillOpen={completionDraftEvent !== null}
-          />
-        )}
 
         <Dialog
           open={resolvedDraftModal !== null}

--- a/client-budokan/src/ui/pages/MapPage.tsx
+++ b/client-budokan/src/ui/pages/MapPage.tsx
@@ -4,6 +4,8 @@ import { ChevronLeft, ChevronRight } from "lucide-react";
 import { useGame } from "@/hooks/useGame";
 import { useGameLevel } from "@/hooks/useGameLevel";
 import { useDraft } from "@/hooks/useDraft";
+import useAccountCustom from "@/hooks/useAccountCustom";
+import { useDojo } from "@/dojo/useDojo";
 import {
   NODES_PER_ZONE,
   TOTAL_ZONES,
@@ -139,6 +141,12 @@ const MapPage: React.FC = () => {
   );
   const { setThemeTemplate } = useTheme();
   const { setMusicPlaylist } = useMusicPlayer();
+  const { account } = useAccountCustom();
+  const {
+    setup: {
+      systemCalls: { startNextLevel },
+    },
+  } = useDojo();
 
   const { game, seed } = useGame({
     gameId: gameId ?? undefined,
@@ -273,9 +281,21 @@ const MapPage: React.FC = () => {
   };
 
   const handlePlay = () => {
-    if (gameId !== null) {
-      navigate("play", gameId);
+    if (gameId === null) return;
+
+    // Fire startNextLevel if the chain is waiting for it (level transition pending).
+    // Navigate immediately — PlayScreen shows "Loading grid" until the tx completes.
+    if (game?.levelTransitionPending && account) {
+      startNextLevel({
+        account,
+        game_id: game.id,
+        current_level: game.level,
+      }).catch((error: unknown) => {
+        console.error("Failed to start next level:", error);
+      });
     }
+
+    navigate("play", gameId);
   };
 
   const activeThemeRaw = mapData.zoneThemes[activeZone] ?? "theme-1";

--- a/client-budokan/src/ui/pages/MapPage.tsx
+++ b/client-budokan/src/ui/pages/MapPage.tsx
@@ -26,12 +26,14 @@ import { useTheme } from "@/ui/elements/theme-provider/hooks";
 import { useMusicPlayer } from "@/contexts/hooks";
 import { useNavigationStore } from "@/stores/navigationStore";
 import {
+  getDraftEventForCompletedLevel,
   getDraftEventForZoneNode,
   getStoredDraftPick,
   isDraftEventCompleted,
 } from "@/utils/draftEvents";
 import PageTopBar from "@/ui/navigation/PageTopBar";
 import LevelPreview from "@/ui/components/map/LevelPreview";
+import LevelCompleteDialog from "@/ui/components/LevelCompleteDialog";
 import ZoneBackground from "@/ui/components/map/ZoneBackground";
 import { Dialog, DialogContent, DialogTitle } from "@/ui/elements/dialog";
 import { Button } from "@/ui/elements/button";
@@ -124,6 +126,12 @@ const MapPage: React.FC = () => {
   );
   const setPendingPreviewLevel = useNavigationStore(
     (state) => state.setPendingPreviewLevel,
+  );
+  const pendingLevelCompletion = useNavigationStore(
+    (state) => state.pendingLevelCompletion,
+  );
+  const setPendingLevelCompletion = useNavigationStore(
+    (state) => state.setPendingLevelCompletion,
   );
   const pendingDraftEvent = useNavigationStore(
     (state) => state.pendingDraftEvent,
@@ -221,6 +229,11 @@ const MapPage: React.FC = () => {
       }),
     [mapData.nodes],
   );
+
+  const completionDraftEvent = useMemo(() => {
+    if (!pendingLevelCompletion) return null;
+    return getDraftEventForCompletedLevel(seed, pendingLevelCompletion.level);
+  }, [pendingLevelCompletion, seed]);
 
 
   /* ---- Swipe handlers (Pointer Events for reliable mobile) ---- */
@@ -607,7 +620,7 @@ const MapPage: React.FC = () => {
         </div>
 
         {/* ---- Level preview modal ---- */}
-        {selectedNode && (
+        {selectedNode && !pendingLevelCompletion && (
           <LevelPreview
             node={selectedNode}
             game={game ?? null}
@@ -615,6 +628,33 @@ const MapPage: React.FC = () => {
             gameId={gameId}
             onPlay={handlePlay}
             onClose={() => setSelectedNode(null)}
+          />
+        )}
+
+        {/* ---- Level complete overlay ---- */}
+        {pendingLevelCompletion && (
+          <LevelCompleteDialog
+            isOpen={true}
+            onClose={() => {
+              const completedLevel = pendingLevelCompletion.level;
+
+              setPendingLevelCompletion(null);
+
+              if (completionDraftEvent) {
+                setPendingDraftEvent(completionDraftEvent);
+                navigate("draft", gameId ?? undefined);
+              } else {
+                setPendingPreviewLevel(completedLevel + 1);
+              }
+            }}
+            level={pendingLevelCompletion.level}
+            levelMoves={pendingLevelCompletion.levelMoves}
+            prevTotalCubes={pendingLevelCompletion.prevTotalCubes}
+            totalCubes={pendingLevelCompletion.totalCubes}
+            prevTotalScore={pendingLevelCompletion.prevTotalScore}
+            totalScore={pendingLevelCompletion.totalScore}
+            gameLevel={pendingLevelCompletion.gameLevel}
+            draftWillOpen={completionDraftEvent !== null}
           />
         )}
 

--- a/client-budokan/src/ui/pages/PlayScreen.tsx
+++ b/client-budokan/src/ui/pages/PlayScreen.tsx
@@ -142,7 +142,7 @@ const PlayScreen: React.FC = () => {
     if (!draftState?.active) return;
     if (gameId === null || gameId === undefined) return;
     navNavigate("draft", gameId);
-  }, [draftState?.active, game, account, gameId, navNavigate, levelCompletionData]);
+  }, [draftState?.active, game, account, gameId, navNavigate]);
 
 
   useEffect(() => {

--- a/client-budokan/src/ui/pages/PlayScreen.tsx
+++ b/client-budokan/src/ui/pages/PlayScreen.tsx
@@ -227,6 +227,7 @@ const PlayScreen: React.FC = () => {
         }).catch((error: unknown) => {
           console.error("Background startNextLevel failed:", error);
         });
+      }
     }
 
     prevGameStateRef.current = {

--- a/client-budokan/src/ui/pages/PlayScreen.tsx
+++ b/client-budokan/src/ui/pages/PlayScreen.tsx
@@ -25,8 +25,6 @@ import GameBoard from "@/ui/components/GameBoard";
 import GameOverDialog from "@/ui/components/GameOverDialog";
 import VictoryDialog from "@/ui/components/VictoryDialog";
 import Connect from "@/ui/components/Connect";
-import LevelCompleteDialog from "@/ui/components/LevelCompleteDialog";
-import { getDraftEventForCompletedLevel } from "@/utils/draftEvents";
 import {
   Dialog,
   DialogContent,
@@ -51,11 +49,8 @@ const PlayScreen: React.FC = () => {
   const gameId = useNavigationStore((s) => s.gameId);
   const navNavigate = useNavigationStore((s) => s.navigate);
   const goBack = useNavigationStore((s) => s.goBack);
-  const setPendingPreviewLevel = useNavigationStore(
-    (s) => s.setPendingPreviewLevel,
-  );
-  const setPendingDraftEvent = useNavigationStore(
-    (s) => s.setPendingDraftEvent,
+  const setPendingLevelCompletion = useNavigationStore(
+    (s) => s.setPendingLevelCompletion,
   );
   const { themeTemplate, setThemeTemplate } = useTheme();
   const { setMusicContext, setMusicPlaylist, playSfx } = useMusicPlayer();
@@ -80,15 +75,6 @@ const PlayScreen: React.FC = () => {
   // Tracks whether the Grid cascade animation has finished for the current move.
   // Level-complete detection is gated on this to prevent checking against a mid-cascade grid.
   const [cascadeComplete, setCascadeComplete] = useState(false);
-  const [levelCompletionData, setLevelCompletionData] = useState<{
-    level: number;
-    levelMoves: number;
-    prevTotalCubes: number;
-    totalCubes: number;
-    prevTotalScore: number;
-    totalScore: number;
-    gameLevel: GameLevelData | null;
-  } | null>(null);
   const prevGameOverRef = useRef<boolean | undefined>(game?.over);
   const prevGameStateRef = useRef<{
     level: number;
@@ -155,7 +141,6 @@ const PlayScreen: React.FC = () => {
     if (!game || !account || game.over) return;
     if (!draftState?.active) return;
     if (gameId === null || gameId === undefined) return;
-    if (levelCompletionData) return; // Don't redirect while showing level-complete dialog
     navNavigate("draft", gameId);
   }, [draftState?.active, game, account, gameId, navNavigate, levelCompletionData]);
 
@@ -207,7 +192,7 @@ const PlayScreen: React.FC = () => {
       } else {
         playSfx("levelup");
       }
-      const completionData = {
+      setPendingLevelCompletion({
         level: prevState.level,
         levelMoves: prevState.levelMoves,
         prevTotalCubes: prevState.totalCubes,
@@ -215,8 +200,7 @@ const PlayScreen: React.FC = () => {
         prevTotalScore: levelStartTotalScoreRef.current,
         totalScore: game.totalScore,
         gameLevel: prevState.gameLevel,
-      };
-      setLevelCompletionData(completionData);
+      });
       levelStartTotalScoreRef.current = game.totalScore;
 
       // Fire startNextLevel in background so the next level grid is ready
@@ -230,6 +214,7 @@ const PlayScreen: React.FC = () => {
           console.error("Background startNextLevel failed:", error);
         });
       }
+      navNavigate("map");
     }
 
     prevGameStateRef.current = {
@@ -255,11 +240,6 @@ const PlayScreen: React.FC = () => {
     playSfx,
     cascadeComplete,
   ]);
-
-  const completionDraftEvent = useMemo(() => {
-    if (!levelCompletionData) return null;
-    return getDraftEventForCompletedLevel(seed, levelCompletionData.level);
-  }, [levelCompletionData, seed]);
 
   const handleSurrender = useCallback(async () => {
     if (!account || !game) return;
@@ -500,31 +480,6 @@ const PlayScreen: React.FC = () => {
         />
       )}
 
-      {levelCompletionData && (
-        <LevelCompleteDialog
-          isOpen={true}
-          onClose={() => {
-            const completedLevel = levelCompletionData.level;
-            setLevelCompletionData(null);
-
-            if (completionDraftEvent) {
-              setPendingDraftEvent(completionDraftEvent);
-              navNavigate("draft", gameId ?? undefined);
-            } else {
-              setPendingPreviewLevel(completedLevel + 1);
-              navNavigate("map");
-            }
-          }}
-          level={levelCompletionData.level}
-          levelMoves={levelCompletionData.levelMoves}
-          prevTotalCubes={levelCompletionData.prevTotalCubes}
-          totalCubes={levelCompletionData.totalCubes}
-          prevTotalScore={levelCompletionData.prevTotalScore}
-          totalScore={levelCompletionData.totalScore}
-          gameLevel={levelCompletionData.gameLevel}
-          draftWillOpen={completionDraftEvent !== null}
-        />
-      )}
 
       {game && !isGameLoading && !isGridLoading && (
         <GameHud

--- a/client-budokan/src/ui/pages/PlayScreen.tsx
+++ b/client-budokan/src/ui/pages/PlayScreen.tsx
@@ -9,7 +9,7 @@ import { useDraft } from "@/hooks/useDraft";
 import useAccountCustom from "@/hooks/useAccountCustom";
 import useViewport from "@/hooks/useViewport";
 import { useDojo } from "@/dojo/useDojo";
-import { isBonusSkill, isWorldEventSkill } from "@/dojo/game/helpers/runDataPacking";
+import { isBonusSkill, isWorldEventSkill, isBossLevel as checkBossLevel } from "@/dojo/game/helpers/runDataPacking";
 import {
   Bonus,
   BonusType,
@@ -36,16 +36,13 @@ import { Button } from "@/ui/elements/button";
 import { generateLevelConfig } from "@/dojo/game/types/level";
 import { deriveZoneThemes, getZone } from "@/hooks/useMapData";
 
-// Module-level guard: survives unmount/remount to prevent duplicate startNextLevel calls
-// when Torii hasn't synced the cleared levelTransitionPending flag yet.
-const startNextLevelIssued = new Set<string>();
 
 const PlayScreen: React.FC = () => {
   useViewport();
 
   const {
     setup: {
-      systemCalls: { surrender, startNextLevel, applyBonus },
+      systemCalls: { surrender, applyBonus },
     },
   } = useDojo();
   const { account } = useAccountCustom();
@@ -71,8 +68,6 @@ const PlayScreen: React.FC = () => {
   const [isVictoryOpen, setIsVictoryOpen] = useState(false);
   const [isConnectDialogOpen, setIsConnectDialogOpen] = useState(false);
   const [isGameLoading, setIsGameLoading] = useState(true);
-  const [isStartingNextLevel, setIsStartingNextLevel] = useState(false);
-  const startNextLevelCalledRef = useRef(false);
   const [activeBonus, setActiveBonus] = useState<BonusType>(BonusType.None);
   const [bonusDescription, setBonusDescription] = useState("");
   const [isSupplyConfirmOpen, setIsSupplyConfirmOpen] = useState(false);
@@ -96,11 +91,9 @@ const PlayScreen: React.FC = () => {
 
   useEffect(() => {
     const level = game?.level ?? 1;
-    const isBossLevel = level > 0 && level % 10 === 0;
+    const isBossLevel = checkBossLevel(level);
     const wasBossLevel =
-      prevBossLevelRef.current != null &&
-      prevBossLevelRef.current > 0 &&
-      prevBossLevelRef.current % 10 === 0;
+      prevBossLevelRef.current != null ? checkBossLevel(prevBossLevelRef.current) : false;
 
     if (isBossLevel && prevBossLevelRef.current !== level) {
       playSfx("boss-intro");
@@ -150,50 +143,6 @@ const PlayScreen: React.FC = () => {
     navNavigate("draft", gameId);
   }, [draftState?.active, game, account, gameId, navNavigate]);
 
-  // Auto-trigger startNextLevel when level_transition_pending is detected
-  useEffect(() => {
-    if (!game || !account || game.over) return;
-    const key = `${game.id}-${game.level}`;
-    if (!game.levelTransitionPending) {
-      // Pending cleared (level started successfully) — clean up guards
-      startNextLevelCalledRef.current = false;
-      startNextLevelIssued.delete(key);
-      return;
-    }
-    // Module-level guard: prevents duplicate call after unmount/remount
-    if (startNextLevelIssued.has(key)) return;
-    if (startNextLevelCalledRef.current) return; // Already called this mount
-    if (isStartingNextLevel) return; // Already in progress
-
-    startNextLevelCalledRef.current = true;
-    startNextLevelIssued.add(key);
-    setIsStartingNextLevel(true);
-
-    const triggerStartNextLevel = async () => {
-      try {
-        await startNextLevel({
-          account,
-          game_id: game.id,
-          current_level: game.level,
-        });
-      } catch (error: unknown) {
-        const errorMsg = error instanceof Error ? error.message : String(error);
-        if (errorMsg.includes("No level transition pending")) {
-          // Already processed — treat as success, keep guards in place
-          console.warn("startNextLevel: already processed, ignoring.");
-        } else {
-          console.error("Failed to start next level:", error);
-          // Real failure — allow retry
-          startNextLevelCalledRef.current = false;
-          startNextLevelIssued.delete(key);
-        }
-      } finally {
-        setIsStartingNextLevel(false);
-      }
-    };
-
-    triggerStartNextLevel();
-  }, [game?.levelTransitionPending, game?.id, game?.level, game?.over, account, startNextLevel, isStartingNextLevel]);
 
   useEffect(() => {
     if (prevGameOverRef.current !== undefined) {
@@ -230,10 +179,14 @@ const PlayScreen: React.FC = () => {
     }
 
     // Gate on cascadeComplete: don't detect level transition until the cascade
-    // animation has fully finished. This prevents the UI from seeing the stale
-    // end-of-level grid and trying to navigate before animations are done.
-    if (prevState && currentLevel > prevState.level && !game.over && cascadeComplete) {
-      if (prevState.level % 10 === 0) {
+    // animation has fully finished. If level changed but cascade isn't done yet,
+    // skip this run entirely (don't update prevState) so we re-detect on next run.
+    if (prevState && currentLevel > prevState.level && !game.over) {
+      if (!cascadeComplete) {
+        // Cascade still running — preserve old prevState so we re-detect later
+        return;
+      }
+      if (checkBossLevel(prevState.level)) {
         playSfx("boss-defeat");
       } else {
         playSfx("levelup");
@@ -541,7 +494,7 @@ const PlayScreen: React.FC = () => {
               className="h-16 w-16 animate-bounce drop-shadow-[0_0_12px_rgba(59,130,246,0.8)]"
             />
             <p className="text-lg font-semibold uppercase tracking-[0.25em] text-slate-100">
-              {isStartingNextLevel ? "Starting next level" : isGameLoading ? "Preparing game" : "Loading grid"}
+              {isGameLoading ? "Preparing game" : "Loading grid"}
             </p>
           </div>
         )}

--- a/client-budokan/src/ui/pages/PlayScreen.tsx
+++ b/client-budokan/src/ui/pages/PlayScreen.tsx
@@ -149,13 +149,15 @@ const PlayScreen: React.FC = () => {
     else setIsConnectDialogOpen(false);
   }, [account]);
 
-  // Redirect to draft page if a draft is active (e.g. zone 1 entry draft at game creation)
+  // Redirect to draft page if a draft is active (e.g. zone 1 entry draft at game creation).
+  // Skip if the level-complete dialog is showing — navigation happens from the dialog's onClose.
   useEffect(() => {
     if (!game || !account || game.over) return;
     if (!draftState?.active) return;
     if (gameId === null || gameId === undefined) return;
+    if (levelCompletionData) return; // Don't redirect while showing level-complete dialog
     navNavigate("draft", gameId);
-  }, [draftState?.active, game, account, gameId, navNavigate]);
+  }, [draftState?.active, game, account, gameId, navNavigate, levelCompletionData]);
 
 
   useEffect(() => {

--- a/client-budokan/src/ui/pages/PlayScreen.tsx
+++ b/client-budokan/src/ui/pages/PlayScreen.tsx
@@ -25,6 +25,8 @@ import GameBoard from "@/ui/components/GameBoard";
 import GameOverDialog from "@/ui/components/GameOverDialog";
 import VictoryDialog from "@/ui/components/VictoryDialog";
 import Connect from "@/ui/components/Connect";
+import LevelCompleteDialog from "@/ui/components/LevelCompleteDialog";
+import { getDraftEventForCompletedLevel } from "@/utils/draftEvents";
 import {
   Dialog,
   DialogContent,
@@ -42,15 +44,18 @@ const PlayScreen: React.FC = () => {
 
   const {
     setup: {
-      systemCalls: { surrender, applyBonus },
+      systemCalls: { surrender, startNextLevel, applyBonus },
     },
   } = useDojo();
   const { account } = useAccountCustom();
   const gameId = useNavigationStore((s) => s.gameId);
   const navNavigate = useNavigationStore((s) => s.navigate);
   const goBack = useNavigationStore((s) => s.goBack);
-  const setPendingLevelCompletion = useNavigationStore(
-    (s) => s.setPendingLevelCompletion,
+  const setPendingPreviewLevel = useNavigationStore(
+    (s) => s.setPendingPreviewLevel,
+  );
+  const setPendingDraftEvent = useNavigationStore(
+    (s) => s.setPendingDraftEvent,
   );
   const { themeTemplate, setThemeTemplate } = useTheme();
   const { setMusicContext, setMusicPlaylist, playSfx } = useMusicPlayer();
@@ -75,6 +80,15 @@ const PlayScreen: React.FC = () => {
   // Tracks whether the Grid cascade animation has finished for the current move.
   // Level-complete detection is gated on this to prevent checking against a mid-cascade grid.
   const [cascadeComplete, setCascadeComplete] = useState(false);
+  const [levelCompletionData, setLevelCompletionData] = useState<{
+    level: number;
+    levelMoves: number;
+    prevTotalCubes: number;
+    totalCubes: number;
+    prevTotalScore: number;
+    totalScore: number;
+    gameLevel: GameLevelData | null;
+  } | null>(null);
   const prevGameOverRef = useRef<boolean | undefined>(game?.over);
   const prevGameStateRef = useRef<{
     level: number;
@@ -191,7 +205,7 @@ const PlayScreen: React.FC = () => {
       } else {
         playSfx("levelup");
       }
-      setPendingLevelCompletion({
+      const completionData = {
         level: prevState.level,
         levelMoves: prevState.levelMoves,
         prevTotalCubes: prevState.totalCubes,
@@ -199,9 +213,20 @@ const PlayScreen: React.FC = () => {
         prevTotalScore: levelStartTotalScoreRef.current,
         totalScore: game.totalScore,
         gameLevel: prevState.gameLevel,
-      });
+      };
+      setLevelCompletionData(completionData);
       levelStartTotalScoreRef.current = game.totalScore;
-      navNavigate("map");
+
+      // Fire startNextLevel in background so the next level grid is ready
+      // by the time the player navigates from the map.
+      if (account) {
+        startNextLevel({
+          account,
+          game_id: game.id,
+          current_level: game.level,
+        }).catch((error: unknown) => {
+          console.error("Background startNextLevel failed:", error);
+        });
     }
 
     prevGameStateRef.current = {
@@ -227,6 +252,11 @@ const PlayScreen: React.FC = () => {
     playSfx,
     cascadeComplete,
   ]);
+
+  const completionDraftEvent = useMemo(() => {
+    if (!levelCompletionData) return null;
+    return getDraftEventForCompletedLevel(seed, levelCompletionData.level);
+  }, [levelCompletionData, seed]);
 
   const handleSurrender = useCallback(async () => {
     if (!account || !game) return;
@@ -464,6 +494,32 @@ const PlayScreen: React.FC = () => {
             navNavigate("home");
           }}
           game={game}
+        />
+      )}
+
+      {levelCompletionData && (
+        <LevelCompleteDialog
+          isOpen={true}
+          onClose={() => {
+            const completedLevel = levelCompletionData.level;
+            setLevelCompletionData(null);
+
+            if (completionDraftEvent) {
+              setPendingDraftEvent(completionDraftEvent);
+              navNavigate("draft", gameId ?? undefined);
+            } else {
+              setPendingPreviewLevel(completedLevel + 1);
+              navNavigate("map");
+            }
+          }}
+          level={levelCompletionData.level}
+          levelMoves={levelCompletionData.levelMoves}
+          prevTotalCubes={levelCompletionData.prevTotalCubes}
+          totalCubes={levelCompletionData.totalCubes}
+          prevTotalScore={levelCompletionData.prevTotalScore}
+          totalScore={levelCompletionData.totalScore}
+          gameLevel={levelCompletionData.gameLevel}
+          draftWillOpen={completionDraftEvent !== null}
         />
       )}
 

--- a/client-budokan/src/ui/pages/SkillTreePage.tsx
+++ b/client-budokan/src/ui/pages/SkillTreePage.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/dojo/game/types/skillData";
 import { getSkillEffectDescription } from "@/dojo/game/types/skillEffects";
 import { SKILL_TREE_COSTS } from "@/dojo/game/helpers/runDataPacking";
+import { MAX_SKILL_LEVEL, BRANCH_POINT_LEVEL, BRANCH_SPLIT_LEVEL } from "@/dojo/game/constants";
 import { getCommonAssetPath } from "@/config/themes";
 import { getSkillTierIconPath } from "@/ui/theme/ImageAssets";
 import PageTopBar from "@/ui/navigation/PageTopBar";
@@ -151,8 +152,8 @@ const SkillTreePage: React.FC = () => {
   const handleUpgrade = useCallback(
     async (skillId: number) => {
       const info = skills[skillId - 1];
-      if (!account || !info || info.level >= 9) return;
-      if (info.level >= 4 && !info.branchChosen) return;
+      if (!account || !info || info.level >= MAX_SKILL_LEVEL) return;
+      if (info.level >= BRANCH_POINT_LEVEL && !info.branchChosen) return;
       const cost = SKILL_TREE_COSTS[info.level];
       if (cubeBalanceNumber < cost) return;
       try {
@@ -590,9 +591,9 @@ const SkillModal: React.FC<SkillModalProps> = ({
   const archetype = ARCHETYPES[skill.archetype];
   const color = archetype.color;
   const currentLevel = info.level;
-  const isBranchRow = targetLevel >= 5;
+  const isBranchRow = targetLevel >= BRANCH_SPLIT_LEVEL;
   const isForkRow = targetLevel === 5;
-  const needsChoice = isForkRow && currentLevel === 4 && !info.branchChosen;
+  const needsChoice = isForkRow && currentLevel === BRANCH_POINT_LEVEL && !info.branchChosen;
 
   const branchForDesc =
     isBranchRow && info.branchChosen
@@ -606,7 +607,7 @@ const SkillModal: React.FC<SkillModalProps> = ({
       ? getSkillEffectDescription(
           skillId,
           currentLevel,
-          currentLevel >= 5 && info.branchChosen
+          currentLevel >= BRANCH_SPLIT_LEVEL && info.branchChosen
             ? info.branchId + 1
             : undefined,
         )
@@ -648,9 +649,9 @@ const SkillModal: React.FC<SkillModalProps> = ({
       effect: string;
       branchLabel?: string;
     }[] = [];
-    for (let lvl = targetLevel; lvl <= 9; lvl++) {
+    for (let lvl = targetLevel; lvl <= MAX_SKILL_LEVEL; lvl++) {
       const c = SKILL_TREE_COSTS[lvl - 1];
-      if (lvl < 5) {
+      if (lvl < BRANCH_SPLIT_LEVEL) {
         levels.push({
           level: lvl,
           cost: c,
@@ -959,7 +960,7 @@ function buildTreeData(
     const def = SKILLS[skill.id];
 
     /* --- core rows 0-3 --- */
-    for (let row = 0; row < 4; row++) {
+    for (let row = 0; row < BRANCH_POINT_LEVEL; row++) {
       const tl = row + 1;
       const cost = SKILL_TREE_COSTS[row];
       const unlocked = info.level >= tl;
@@ -1056,11 +1057,11 @@ function buildTreeData(
     });
 
     /* --- branch rows 4-8 --- */
-    for (let row = 4; row < 9; row++) {
+    for (let row = BRANCH_POINT_LEVEL; row < MAX_SKILL_LEVEL; row++) {
       const tl = row + 1;
       const cost = SKILL_TREE_COSTS[row];
-      const fork = row === 4;
-      const nc = fork && info.level === 4 && !info.branchChosen;
+      const fork = row === BRANCH_POINT_LEVEL;
+      const nc = fork && info.level === BRANCH_POINT_LEVEL && !info.branchChosen;
 
       for (const side of [0, 1] as const) {
         const n = computeBranchNode(info, tl, cost, cubeBalance, nc, side);


### PR DESCRIPTION
## Summary

- **World map node algorithm rewrite**: Dynamic mid-draft placement from seed (was hardcoded at position 5), guaranteed monotonic vertical spacing, lane-alternation layout preventing node overlap, entry draft gates level 1
- **Skill tree**: Level display 1-10 (not 0-9), level badges, off-by-one fix for contract skill upgrades (0-indexed vs 1-indexed), optimistic UI updates
- **Draft page**: Hades-style boon aesthetic redesign, proper skill icon with level badge and effect description, fixed draft level display
- **Panel contrast**: Standardized `bg-slate-900/90 border-white/10` across all panels, top bars reverted to `bg-slate-900/70`
- **Map header**: Shows "WORLD MAP / Zone N - ThemeName", renamed theme-9 Pueblo→Tribal
- **Cube earnings**: Fixed to 5/3/1 in LevelPreview
- **Quest page**: Fixed Daily Champion subtitle spacing, boosted completed quest contrast

## Files changed (22 files, +890 −656)

### Map rewrite
- `useMapData.ts` — Dynamic zone node sequence from seed, `contractLevelToNodeIndex` takes seed, level 1 locked until entry draft done
- `useMapLayout.ts` — Even Y spacing, 3-lane zigzag with forced alternation, pre-boss outer lane
- `MapPage.tsx` — Uses `node.draftPhase` directly, removed `MID_DRAFT_NODE_IN_ZONE`

### Draft redesign
- `DraftPage.tsx` — Hades-style UI with skill icons, level badges, effect descriptions
- `draftEvents.ts` — Added `skillId` to `StoredDraftPick`

### Skill tree fixes
- `SkillTreePage.tsx` — Level 1-10 display, level badges
- `contractSystems.ts` — `skill_id - 1` fix for 0-indexed contract
- `useSkillTree.tsx` — Optimistic updates

### UI polish
- `QuestsPage.tsx`, `SettingsPage.tsx`, `LeaderboardPage.tsx`, `MyGamesPage.tsx` — Panel contrast standardization
- `LevelPreview.tsx` — Cube earnings 5/3/1
- `themes.ts` — Pueblo→Tribal rename