### PR TITLE
fix: profile shows USDC only, resolves other player names, scopes ach…

### DIFF
--- a/client-budokan/src/hooks/useAchievements.ts
+++ b/client-budokan/src/hooks/useAchievements.ts
@@ -16,8 +16,9 @@ interface UseAchievementsResult {
   isLoading: boolean;
 }
 
-export const useAchievements = (): UseAchievementsResult => {
-  const { address } = useAccount();
+export const useAchievements = (playerAddress?: string): UseAchievementsResult => {
+  const { address: connectedAddress } = useAccount();
+  const resolvedAddress = playerAddress ?? connectedAddress;
   const {
     setup: {
       contractComponents: { AchievementAdvancement, AchievementCompletion },
@@ -25,13 +26,13 @@ export const useAchievements = (): UseAchievementsResult => {
   } = useDojo();
 
   const ownerBigInt = useMemo(() => {
-    if (!address) return null;
+    if (!resolvedAddress) return null;
     try {
-      return BigInt(address);
+      return BigInt(resolvedAddress);
     } catch {
       return null;
     }
-  }, [address]);
+  }, [resolvedAddress]);
 
   const advancementEntityIds = useEntityQuery([Has(AchievementAdvancement)]);
   const completionEntityIds = useEntityQuery([Has(AchievementCompletion)]);

--- a/client-budokan/src/ui/components/profile/AchievementsTab.tsx
+++ b/client-budokan/src/ui/components/profile/AchievementsTab.tsx
@@ -20,6 +20,7 @@ const itemVariants: any = {
 
 interface AchievementsTabProps {
   colors: ThemeColors;
+  playerAddress?: string;
 }
 
 const TIER_LABELS = ["I", "II", "III", "IV"] as const;
@@ -38,8 +39,8 @@ const RARITY_COLORS = {
   Legendary: "#FFD86E",
 } as const;
 
-const AchievementsTab: React.FC<AchievementsTabProps> = ({ colors }) => {
-  const { achievements } = useAchievements();
+const AchievementsTab: React.FC<AchievementsTabProps> = ({ colors, playerAddress }) => {
+  const { achievements } = useAchievements(playerAddress);
 
   const totalUnlocked = achievements.filter((a) => a.completed).length;
   const total = achievements.length;

--- a/client-budokan/src/ui/components/profile/OverviewTab.tsx
+++ b/client-budokan/src/ui/components/profile/OverviewTab.tsx
@@ -30,6 +30,8 @@ interface OverviewTabProps {
   combo4Count: number;
   totalBosses: number;
   walletBalances: WalletBalance[];
+  totalPortfolioValue?: number;
+  isOwnProfile?: boolean;
   onFundAccount: () => void;
 }
 
@@ -40,6 +42,8 @@ const OverviewTab: React.FC<OverviewTabProps> = ({
   combo4Count,
   totalBosses,
   walletBalances,
+  totalPortfolioValue,
+  isOwnProfile = true,
   onFundAccount,
 }) => {
   const stats = [
@@ -49,7 +53,7 @@ const OverviewTab: React.FC<OverviewTabProps> = ({
     { label: "Guardians", value: totalBosses > 0 ? totalBosses.toLocaleString() : "--" },
   ];
 
-  const totalUsdcValue = walletBalances.reduce((sum, b) => sum + b.usdcValue, 0);
+  const totalUsdcValue = totalPortfolioValue ?? walletBalances.reduce((sum, b) => sum + b.usdcValue, 0);
 
   return (
     <motion.div variants={containerVariants} initial="hidden" animate="show" className="flex flex-col gap-4 pb-2">
@@ -83,16 +87,18 @@ const OverviewTab: React.FC<OverviewTabProps> = ({
           ))}
         </div>
 
-        <motion.button
-          variants={itemVariants}
-          type="button"
-          onClick={onFundAccount}
-          className="mt-2 flex w-full items-center justify-center gap-2 rounded-xl border px-3 py-2.5 font-sans text-[12px] font-bold uppercase tracking-[0.08em] transition-colors hover:bg-white/[0.06]"
-          style={{ borderColor: `${colors.accent}55`, color: colors.accent }}
-        >
-          <Wallet size={14} />
-          Fund Account
-        </motion.button>
+        {isOwnProfile && (
+          <motion.button
+            variants={itemVariants}
+            type="button"
+            onClick={onFundAccount}
+            className="mt-2 flex w-full items-center justify-center gap-2 rounded-xl border px-3 py-2.5 font-sans text-[12px] font-bold uppercase tracking-[0.08em] transition-colors hover:bg-white/[0.06]"
+            style={{ borderColor: `${colors.accent}55`, color: colors.accent }}
+          >
+            <Wallet size={14} />
+            Fund Account
+          </motion.button>
+        )}
       </section>
 
       <section>

--- a/client-budokan/src/ui/pages/ProfilePage.tsx
+++ b/client-budokan/src/ui/pages/ProfilePage.tsx
@@ -4,6 +4,7 @@ import { motion } from "motion/react";
 import { useTheme } from "@/ui/elements/theme-provider/hooks";
 import { getThemeColors } from "@/config/themes";
 import { useControllerUsername } from "@/hooks/useControllerUsername";
+import { useGetUsernames, normalizeAddress } from "@/hooks/useGetUsernames";
 import { usePlayerMeta } from "@/hooks/usePlayerMeta";
 import { useZStarBalance } from "@/hooks/useZStarBalance";
 import { useZoneProgress } from "@/hooks/useZoneProgress";
@@ -75,7 +76,13 @@ const ProfilePage: React.FC = () => {
   const { balance: lordsBalance } = useTokenBalance(LORDS_TOKEN, viewingAddress);
 
   // Resolve username for viewed profile
-  const username = isOwnProfile ? connectedUsername : undefined;
+  const viewedAddresses = useMemo(() => viewingAddress && !isOwnProfile ? [viewingAddress] : [], [viewingAddress, isOwnProfile]);
+  const { usernames: resolvedUsernames } = useGetUsernames(viewedAddresses);
+  const username = isOwnProfile
+    ? connectedUsername
+    : viewingAddress
+      ? resolvedUsernames?.get(normalizeAddress(viewingAddress)) ?? undefined
+      : undefined;
 
   const xp = playerMeta?.lifetimeXp ?? 0;
   const level = getLevelFromXp(xp);
@@ -91,11 +98,15 @@ const ProfilePage: React.FC = () => {
   const strkPriceUsd = 0.5;
   const lordsPriceUsd = 0.03;
 
+  // Only display USDC; STRK/LORDS tracked for portfolio total
   const walletBalances = useMemo<WalletBalance[]>(() => [
-    { label: "STRK", symbol: "STRK", amount: strkAmount.toFixed(2), usdcValue: strkAmount * strkPriceUsd, icon: "⚡" },
     { label: "USDC", symbol: "USDC", amount: usdcAmount.toFixed(2), usdcValue: usdcAmount, icon: "💵" },
-    { label: "LORDS", symbol: "LORDS", amount: lordsAmount.toFixed(2), usdcValue: lordsAmount * lordsPriceUsd, icon: "🏰" },
-  ], [strkAmount, strkPriceUsd, usdcAmount, lordsAmount, lordsPriceUsd]);
+  ], [usdcAmount]);
+
+  const totalPortfolioValue = useMemo(
+    () => strkAmount * strkPriceUsd + usdcAmount + lordsAmount * lordsPriceUsd,
+    [strkAmount, strkPriceUsd, usdcAmount, lordsAmount, lordsPriceUsd],
+  );
 
   const [tab, setTab] = useState<(typeof TABS)[number]>("Overview");
   const [unlockZone, setUnlockZone] = useState<ZoneProgressData | null>(null);
@@ -227,8 +238,9 @@ const ProfilePage: React.FC = () => {
               combo4Count={playerStats.combo4Count}
               totalBosses={playerStats.totalBosses}
               walletBalances={walletBalances}
+              totalPortfolioValue={totalPortfolioValue}
+              isOwnProfile={isOwnProfile}
               onFundAccount={() => {
-                // TODO: integrate Cartridge funding flow or bridge
                 window.open("https://starkgate.starknet.io", "_blank");
               }}
             />
@@ -243,7 +255,7 @@ const ProfilePage: React.FC = () => {
             />
           )}
 
-          {tab === "Achievements" && <AchievementsTab colors={colors} />}
+          {tab === "Achievements" && <AchievementsTab colors={colors} playerAddress={viewingAddress} />}
           </motion.div>
 
         </motion.div>


### PR DESCRIPTION
…ievements

- Wallet: only display USDC balance (STRK/LORDS still tracked for portfolio total value)
- Other player profiles: resolve username via useGetUsernames instead of showing "Player"
- Fund Account button hidden when viewing another player's profile
- Achievements: useAchievements accepts optional playerAddress param, AchievementsTab shows viewed player's achievements not connected user's