### PR TITLE
perf: fix mobile FPS drops in cascades, transitions, and animations

### DIFF
--- a/client-budokan/src/grid.css
+++ b/client-budokan/src/grid.css
@@ -16,16 +16,14 @@
   0% {
     transform: scale(1);
     opacity: 1;
-    filter: brightness(1);
   }
   30% {
     transform: scale(1.15);
-    filter: brightness(2.5);
+    opacity: 0.95;
   }
   100% {
     transform: scale(0);
     opacity: 0;
-    filter: brightness(3);
   }
 }
 
@@ -83,8 +81,12 @@
   inset: 0;
   z-index: 15;
   pointer-events: none;
-  box-shadow: inset 0 0 50px rgba(239, 68, 68, 0.15),
-              inset 0 0 100px rgba(127, 29, 29, 0.1);
+  background: radial-gradient(
+    ellipse at center,
+    transparent 40%,
+    rgba(239, 68, 68, 0.12) 70%,
+    rgba(127, 29, 29, 0.08) 100%
+  );
   animation: bossVignettePulse 3s infinite ease-in-out;
 }
 
@@ -97,6 +99,59 @@
 .boss-hud-bar {
   border-bottom: 2px solid rgba(239, 68, 68, 0.4);
   box-shadow: 0 2px 12px rgba(239, 68, 68, 0.2);
+}
+
+/* ─── Chevron pulse (next-row indicator) ─── */
+@keyframes chevronPulse {
+  0%, 100% { opacity: 0.3; transform: translateY(0); }
+  50% { opacity: 1; transform: translateY(-2px); }
+}
+.chevron-pulse {
+  animation: chevronPulse 2s ease-in-out infinite;
+}
+
+/* ─── Map: playing node glow (CSS, not JS) ─── */
+@keyframes mapPlayingGlow {
+  0%, 100% { opacity: 0.1; }
+  50% { opacity: 0.3; }
+}
+.map-playing-glow {
+  animation: mapPlayingGlow 2s ease-in-out infinite;
+}
+
+@keyframes mapPlayingRing {
+  0% { opacity: 0.9; transform: scale(1); }
+  100% { opacity: 0.25; transform: scale(1.35); }
+}
+.map-playing-ring {
+  animation: mapPlayingRing 1.2s ease-out infinite;
+}
+
+/* ─── Map: guardian node pulse (CSS, not JS) ─── */
+@keyframes mapGuardianPulse {
+  0%, 100% { transform: scale(1); }
+  50% { transform: scale(1.04); }
+}
+.map-guardian-pulse {
+  animation: mapGuardianPulse 3s ease-in-out infinite;
+}
+
+/* ─── Guardian portrait pulse (CSS, not JS) ─── */
+@keyframes guardianPulse {
+  0%, 100% { transform: scale(1); }
+  50% { transform: scale(1.03); }
+}
+.guardian-pulse {
+  animation: guardianPulse 4s ease-in-out infinite;
+}
+
+/* ─── Home page falling blocks (CSS, not JS) ─── */
+@keyframes fallingBlock {
+  0%   { transform: translateY(-20px); opacity: 0; }
+  3%   { opacity: 0.85; }
+  35%  { transform: translateY(280px); opacity: 0.7; }
+  36%  { transform: translateY(280px); opacity: 0; }
+  100% { transform: translateY(-20px); opacity: 0; }
 }
 
 /* ─── Combo text shine ─── */

--- a/client-budokan/src/hooks/useTransitionBlocks.ts
+++ b/client-budokan/src/hooks/useTransitionBlocks.ts
@@ -3,7 +3,10 @@ import { useState, useCallback, useRef } from "react";
 const TRANSITION_TIMEOUT_MS = 500;
 
 const useTransitionBlocks = () => {
-  const [transitioningBlocks, setTransitioningBlocks] = useState<number[]>([]);
+  // Track block IDs in a ref to avoid re-renders on every transition start/end.
+  // Only expose a boolean that flips twice per gravity phase (start → end).
+  const blocksRef = useRef<Set<number>>(new Set());
+  const [isTransitioning, setIsTransitioning] = useState(false);
   const timeoutsRef = useRef<Map<number, ReturnType<typeof setTimeout>>>(
     new Map()
   );
@@ -18,17 +21,17 @@ const useTransitionBlocks = () => {
 
   const handleTransitionBlockStart = useCallback(
     (id: number) => {
-      setTransitioningBlocks((prev) => {
-        return prev.includes(id) ? prev : [...prev, id];
-      });
+      blocksRef.current.add(id);
+      setIsTransitioning(true);
 
       // Safety net: auto-remove after timeout in case transitionend never fires
       clearBlockTimeout(id);
       const timeout = setTimeout(() => {
         timeoutsRef.current.delete(id);
-        setTransitioningBlocks((prev) =>
-          prev.filter((blockId) => blockId !== id)
-        );
+        blocksRef.current.delete(id);
+        if (blocksRef.current.size === 0) {
+          setIsTransitioning(false);
+        }
       }, TRANSITION_TIMEOUT_MS);
       timeoutsRef.current.set(id, timeout);
     },
@@ -38,15 +41,16 @@ const useTransitionBlocks = () => {
   const handleTransitionBlockEnd = useCallback(
     (id: number) => {
       clearBlockTimeout(id);
-      setTransitioningBlocks((prev) =>
-        prev.filter((blockId) => blockId !== id)
-      );
+      blocksRef.current.delete(id);
+      if (blocksRef.current.size === 0) {
+        setIsTransitioning(false);
+      }
     },
     [clearBlockTimeout]
   );
 
   return {
-    transitioningBlocks,
+    isTransitioning,
     handleTransitionBlockStart,
     handleTransitionBlockEnd,
   };

--- a/client-budokan/src/ui/components/GameBoard.tsx
+++ b/client-budokan/src/ui/components/GameBoard.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect, useMemo, useRef } from "react";
-import { motion } from "motion/react";
 import { ChevronUp } from "lucide-react";
 import Grid from "./Grid";
 import { transformDataContractIntoBlock } from "@/utils/gridUtils";
@@ -98,12 +97,9 @@ const GameBoard: React.FC<GameBoardProps> = ({
           onNextLineUpdate={setNextLineOverride}
         />
         <div className="mt-1 flex items-center justify-center gap-1 py-0.5">
-          <motion.div
-            animate={{ opacity: [0.3, 1, 0.3], y: [0, -2, 0] }}
-            transition={{ duration: 2, repeat: Infinity }}
-          >
+          <div className="chevron-pulse">
             <ChevronUp size={14} className="text-white/50" />
-          </motion.div>
+          </div>
           <span className="text-[10px] font-bold uppercase tracking-[0.2em] text-white/50">
             Next Row
           </span>

--- a/client-budokan/src/ui/components/Grid.tsx
+++ b/client-budokan/src/ui/components/Grid.tsx
@@ -111,7 +111,7 @@ const Grid: React.FC<GridProps> = ({
   const { shouldBounce, animateText, resetAnimateText, setAnimateText } =
     useGridAnimations(lineExplodedCount);
   const {
-    transitioningBlocks,
+    isTransitioning,
     handleTransitionBlockStart,
     handleTransitionBlockEnd,
   } = useTransitionBlocks();
@@ -334,6 +334,21 @@ const Grid: React.FC<GridProps> = ({
     onDragStart(e.clientX, block);
   }, [onDragStart, setIsTxProcessing]);
 
+  // Stable callback refs — identity never changes so Block's React.memo works.
+  const handlePointerDownRef = useRef(handlePointerDown);
+  handlePointerDownRef.current = handlePointerDown;
+  const stablePointerDown = useCallback(
+    (e: React.PointerEvent<SVGGElement>, block: Block) => handlePointerDownRef.current(e, block), [],
+  );
+
+  const handleTransitionStartRef = useRef(handleTransitionBlockStart);
+  handleTransitionStartRef.current = handleTransitionBlockStart;
+  const stableTransitionStart = useCallback((id: number) => handleTransitionStartRef.current(id), []);
+
+  const handleTransitionEndRef = useRef(handleTransitionBlockEnd);
+  handleTransitionEndRef.current = handleTransitionBlockEnd;
+  const stableTransitionEnd = useCallback((id: number) => handleTransitionEndRef.current(id), []);
+
   // Document-level listeners for move and end (works outside SVG bounds)
   useEffect(() => {
     const move = (e: PointerEvent) => onDragMoveRef.current(e.clientX);
@@ -494,28 +509,39 @@ const Grid: React.FC<GridProps> = ({
 
   // STATE MACHINE
   useEffect(() => {
-    const intervalRef = { current: null as NodeJS.Timeout | null };
-    const applyGravityWithInterval = () => {
-      intervalRef.current = setInterval(() => applyGravity(), gravitySpeed);
+    let rafId: number | null = null;
+    const applyGravityWithRAF = () => {
+      // Start from now so the first tick waits gravitySpeed ms —
+      // this gives CSS transitions time to start and fire transitionstart
+      // events before we check isTransitioning.
+      let lastTick = performance.now();
+      const step = (timestamp: number) => {
+        if (timestamp - lastTick >= gravitySpeed) {
+          lastTick = timestamp;
+          applyGravity();
+        }
+        rafId = requestAnimationFrame(step);
+      };
+      rafId = requestAnimationFrame(step);
     };
 
     switch (gameState) {
       case GameState.GRAVITY:
       case GameState.GRAVITY2:
       case GameState.GRAVITY_BONUS:
-        if (!isMoving && transitioningBlocks.length === 0) {
+        if (!isMoving && !isTransitioning) {
           switch (gameState) {
             case GameState.GRAVITY: setGameState(GameState.LINE_CLEAR); break;
             case GameState.GRAVITY2: setGameState(GameState.LINE_CLEAR2); break;
             case GameState.GRAVITY_BONUS: setGameState(GameState.LINE_CLEAR_BONUS); break;
           }
         } else {
-          applyGravityWithInterval();
+          applyGravityWithRAF();
         }
         break;
 
       case GameState.ADD_LINE:
-        if (transitioningBlocks.length > 0) break;
+        if (isTransitioning) break;
         if (!currentMove) {
           setIsMoving(false);
           setGameState(GameState.WAITING);
@@ -608,9 +634,9 @@ const Grid: React.FC<GridProps> = ({
     }
 
     return () => {
-      if (intervalRef.current) clearInterval(intervalRef.current);
+      if (rafId !== null) cancelAnimationFrame(rafId);
     };
-  }, [gameState, isMoving, transitioningBlocks]);
+  }, [gameState, isMoving, isTransitioning]);
 
   // =================== RENDER ===================
 
@@ -740,9 +766,9 @@ const Grid: React.FC<GridProps> = ({
               state={gameState}
               isExploding={explodingRows.has(block.y)}
               blockImages={blockImages}
-              onPointerDown={handlePointerDown}
-              onTransitionBlockStart={handleTransitionBlockStart}
-              onTransitionBlockEnd={handleTransitionBlockEnd}
+              onPointerDown={stablePointerDown}
+              onTransitionBlockStart={stableTransitionStart}
+              onTransitionBlockEnd={stableTransitionEnd}
             />
           ))}
         </g>

--- a/client-budokan/src/ui/components/shared/ThemeBackground.tsx
+++ b/client-budokan/src/ui/components/shared/ThemeBackground.tsx
@@ -17,7 +17,7 @@ const ThemeBackground: React.FC = () => {
           draggable={false}
         />
       </div>
-      <div className="fixed inset-0 -z-10 bg-[linear-gradient(180deg,rgba(4,8,18,0.72)_0%,rgba(4,8,18,0.56)_40%,rgba(4,8,18,0.88)_100%)] backdrop-blur-[4px]" />
+      <div className="fixed inset-0 -z-10 bg-[linear-gradient(180deg,rgba(4,8,18,0.78)_0%,rgba(4,8,18,0.62)_40%,rgba(4,8,18,0.92)_100%)]" />
     </>
   );
 };

--- a/client-budokan/src/ui/pages/HomePage.tsx
+++ b/client-budokan/src/ui/pages/HomePage.tsx
@@ -127,20 +127,11 @@ const CtaGuardian: React.FC = () => {
       className="relative mx-auto mt-2 flex max-w-[360px] flex-col items-center gap-4"
     >
       {/* Guardian portrait in a circle */}
-      <motion.div
-        className="relative h-36 w-36 overflow-hidden rounded-full"
+      <div
+        className="relative h-36 w-36 overflow-hidden rounded-full guardian-pulse"
         style={{
           border: `3px solid ${gColors.accent}44`,
           boxShadow: `0 0 30px ${gColors.accent}22`,
-        }}
-        initial={{ opacity: 0, scale: 0.85 }}
-        animate={{
-          opacity: 1,
-          scale: [1, 1.03, 1],
-        }}
-        transition={{
-          opacity: { delay: 0.2, duration: 0.5 },
-          scale: { delay: 0.5, duration: 4, repeat: Infinity, ease: "easeInOut" },
         }}
       >
         <img
@@ -149,7 +140,7 @@ const CtaGuardian: React.FC = () => {
           className="h-full w-full object-cover"
           draggable={false}
         />
-      </motion.div>
+      </div>
 
       {/* Catchphrase */}
       <p className="text-center font-sans text-[14px] italic text-white/50">
@@ -168,7 +159,7 @@ const CtaGuardian: React.FC = () => {
           line.blocks.map((b, bi) => {
             const cellPct = 100 / CELLS;
             return (
-              <motion.img
+              <img
                 key={`${li}-${bi}`}
                 src={blockSrcs[b.size]}
                 alt=""
@@ -177,19 +168,7 @@ const CtaGuardian: React.FC = () => {
                   left: `${b.cellX * cellPct}%`,
                   width: `${b.size * cellPct}%`,
                   aspectRatio: `${b.size} / 1`,
-                }}
-                animate={{
-                  y: [-20, 280],
-                  opacity: [0, 0.85, 0.8, 0.7],
-                }}
-                transition={{
-                  delay: line.delay,
-                  duration: line.duration / b.speed,
-                  repeat: Infinity,
-                  // All blocks in a line must restart together:
-                  // total = duration + repeatDelay = totalCycle (constant per line)
-                  repeatDelay: line.totalCycle - line.duration / b.speed,
-                  ease: "easeIn",
+                  animation: `fallingBlock ${line.totalCycle}s ease-in ${line.delay}s infinite`,
                 }}
                 draggable={false}
               />

--- a/client-budokan/src/ui/pages/MapPage.tsx
+++ b/client-budokan/src/ui/pages/MapPage.tsx
@@ -508,11 +508,9 @@ const MapPage: React.FC = () => {
               const badgeX = guardianX + gr * 0.7;
               const badgeY = guardianY + gr * 0.7;
               return (
-                <motion.g
+                <g
                   onClick={() => setShowGreeting(true)}
-                  initial={{ scale: 0, opacity: 0 }}
-                  animate={{ scale: [1, 1.04, 1], opacity: 1 }}
-                  transition={{ scale: { duration: 3, repeat: Infinity, ease: "easeInOut" }, opacity: { delay: 0.1, duration: 0.3 } }}
+                  className="map-guardian-pulse"
                   style={{ cursor: "pointer", transformOrigin: `${guardianX}px ${guardianY}px` }}
                 >
                   <clipPath id="guardian-clip">
@@ -531,7 +529,7 @@ const MapPage: React.FC = () => {
                   <circle cx={badgeX} cy={badgeY} r={badgeR} fill={colors.accent} />
                   <text x={badgeX} y={badgeY + 0.2} textAnchor="middle" dominantBaseline="central" fill="#0a1628" fontSize={2.4} fontWeight="bold" fontFamily="Outfit, sans-serif">?</text>
                   <text x={guardianX} y={guardianY + gr + 2.5} textAnchor="middle" dominantBaseline="central" fill={colors.accent} fontSize={2} fontWeight="bold" fontFamily="Outfit, sans-serif">{guardian.name}</text>
-                </motion.g>
+                </g>
               );
             })()}
 
@@ -628,33 +626,22 @@ const MapPage: React.FC = () => {
 
                   {node.state === "playing" && (
                     <>
-                      <motion.circle
+                      <circle
                         cx={cx}
                         cy={cy}
                         r={r + 2.5}
                         fill={colors.accent}
-                        initial={{ opacity: 0.1 }}
-                        animate={{ opacity: [0.1, 0.3, 0.1] }}
-                        transition={{
-                          duration: 2,
-                          repeat: Infinity,
-                          ease: "easeInOut",
-                        }}
+                        className="map-playing-glow"
                       />
-                      <motion.circle
+                      <circle
                         cx={cx}
                         cy={cy}
                         r={r + 1.8}
                         fill="none"
                         stroke={colors.accent}
                         strokeWidth={1}
-                        initial={{ opacity: 0.9, scale: 1 }}
-                        animate={{ opacity: 0.25, scale: 1.35 }}
-                        transition={{
-                          duration: 1.2,
-                          repeat: Infinity,
-                          ease: "easeOut",
-                        }}
+                        className="map-playing-ring"
+                        style={{ transformOrigin: `${cx}px ${cy}px` }}
                       />
                     </>
                   )}
@@ -692,28 +679,16 @@ const MapPage: React.FC = () => {
                           const starX = cx - 2.5 + i * 2.5;
                           const starY = cy + r + 2.5;
                           return (
-                            <motion.text
+                            <text
                               key={i}
-                              initial={{ opacity: 0, scale: 0 }}
-                              animate={{
-                                opacity: 1,
-                                scale: 1,
-                                fill: filled ? "#FACC15" : "rgba(255,255,255,0.3)",
-                              }}
-                              transition={{
-                                delay: node.nodeInZone * 0.06 + 0.3 + i * 0.1,
-                                type: "spring",
-                                stiffness: 300,
-                                damping: 20,
-                              }}
-                              style={{ transformOrigin: `${starX}px ${starY}px` }}
+                              fill={filled ? "#FACC15" : "rgba(255,255,255,0.3)"}
                               x={starX}
                               y={starY}
                               fontSize={2}
                               textAnchor="middle"
                             >
                               ★
-                            </motion.text>
+                            </text>
                           );
                         })}
                       </g>


### PR DESCRIPTION
Grid cascade:
- Convert transitioningBlocks from useState to useRef+boolean, cutting state machine re-runs from ~40 to 2 per gravity tick
- Stabilize callback props via ref wrappers so Block's React.memo works (only moved blocks re-render, not all ~80)
- Replace setInterval gravity with requestAnimationFrame for frame-synced updates; delay first tick to let CSS transitions start

CSS perf:
- Remove filter:brightness() from explosion (compositor-only now)
- Remove backdrop-blur from ThemeBackground (constant GPU tax)
- Replace boss vignette animated box-shadow with radial-gradient+opacity

Motion → CSS conversions:
- HomePage: 48 motion.img falling blocks → CSS @keyframes fallingBlock
- HomePage: guardian portrait pulse → CSS .guardian-pulse
- MapPage: 30 motion.text stars → plain <text>
- MapPage: playing node pulses → CSS .map-playing-glow/.map-playing-ring
- MapPage: guardian node pulse → CSS .map-guardian-pulse
- GameBoard: ChevronUp pulse → CSS .chevron-pulse, drop motion import