### PR TITLE
feat(client): receipt-based fast sync + smooth integer-snap drag

### DIFF
--- a/client-budokan/src/dojo/rpcReader.ts
+++ b/client-budokan/src/dojo/rpcReader.ts
@@ -1,13 +1,20 @@
 /**
- * Parse Game model data from TX receipt events.
+ * Parse Dojo model writes from TX receipt events.
+ *
  * Dojo StoreSetRecord events format:
  *   data[0] = num_keys
  *   data[1..num_keys] = key fields (game_id)
  *   data[num_keys+1] = num_values
  *   data[num_keys+2..] = value fields in struct order
+ *
+ * The contract may emit multiple StoreSetRecord events to the same model per
+ * TX (intermediate states). Always prefer the LAST matching event — it carries
+ * the authoritative final state.
  */
 
 import { Game } from "@/dojo/game/models/game";
+import { useReceiptGameStore } from "@/stores/receiptGameStore";
+import type { ReceiptGameLevelComponent } from "@/stores/receiptGameStore";
 
 export interface ContractEvent {
   data?: string[];
@@ -21,15 +28,18 @@ export interface ReceiptGameData {
   game: Game;
 }
 
+export interface ReceiptGameSeedData {
+  seed: bigint;
+  levelSeed: bigint;
+  vrfEnabled: boolean;
+}
+
 export function parseGameFromReceipt(
   events: ContractEvent[],
   gameId: bigint,
 ): ReceiptGameData | null {
   if (!events || events.length === 0) return null;
 
-  // Use the LAST matching StoreSetRecord event — the contract may emit
-  // multiple writes to the Game model per TX (intermediate states).
-  // The last one is the authoritative final state (with correct over flag).
   let result: ReceiptGameData | null = null;
 
   for (let i = 0; i < events.length; i++) {
@@ -86,4 +96,146 @@ export function parseGameFromReceipt(
   }
 
   return result;
+}
+
+/**
+ * Extract GameSeed model writes from a TX receipt.
+ *
+ * GameSeed schema (contracts/src/models/game.cairo):
+ *   key:    game_id: felt252
+ *   values: seed: felt252, level_seed: felt252, vrf_enabled: bool   (3 values)
+ */
+export function parseGameSeedFromReceipt(
+  events: ContractEvent[],
+  gameId: bigint,
+): ReceiptGameSeedData | null {
+  if (!events || events.length === 0) return null;
+
+  let result: ReceiptGameSeedData | null = null;
+
+  for (let i = 0; i < events.length; i++) {
+    const data = events[i].data ?? [];
+    // 1 (num_keys) + 1 (game_id) + 1 (num_values) + 3 (values) = 6 minimum
+    if (data.length < 6) continue;
+
+    try {
+      const numKeys = Number(BigInt(data[0]));
+      if (numKeys !== 1) continue;
+
+      const eventGameId = BigInt(data[1]);
+      if (eventGameId !== gameId) continue;
+
+      const numValues = Number(BigInt(data[1 + numKeys]));
+      if (numValues !== 3) continue;
+
+      const valStart = 1 + numKeys + 1;
+      const seed = BigInt(data[valStart]);
+      const levelSeed = BigInt(data[valStart + 1]);
+      const vrfEnabled = BigInt(data[valStart + 2]) !== 0n;
+
+      // Reject the zero-seed write that occurs when GameSeed is first
+      // declared but not yet populated (defensive — shouldn't happen in
+      // create_game, but cheap guard).
+      if (seed === 0n) continue;
+
+      result = { seed, levelSeed, vrfEnabled };
+    } catch {
+      continue;
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Extract GameLevel model writes from a TX receipt.
+ *
+ * GameLevel schema (contracts/src/models/game.cairo):
+ *   key:    game_id: felt252
+ *   values (in struct order, all unsigned ints, one felt each):
+ *     level, points_required, max_moves, difficulty,
+ *     constraint_type, constraint_value, constraint_count,
+ *     constraint2_type, constraint2_value, constraint2_count,
+ *     mutator_id    (11 values)
+ */
+export function parseGameLevelFromReceipt(
+  events: ContractEvent[],
+  gameId: bigint,
+): ReceiptGameLevelComponent | null {
+  if (!events || events.length === 0) return null;
+
+  let result: ReceiptGameLevelComponent | null = null;
+
+  for (let i = 0; i < events.length; i++) {
+    const data = events[i].data ?? [];
+    // 1 (num_keys) + 1 (game_id) + 1 (num_values) + 11 (values) = 14 minimum
+    if (data.length < 14) continue;
+
+    try {
+      const numKeys = Number(BigInt(data[0]));
+      if (numKeys !== 1) continue;
+
+      const eventGameId = BigInt(data[1]);
+      if (eventGameId !== gameId) continue;
+
+      const numValues = Number(BigInt(data[1 + numKeys]));
+      if (numValues !== 11) continue;
+
+      const valStart = 1 + numKeys + 1;
+      const level = Number(BigInt(data[valStart]));
+      // Reject pre-init writes where level=0 (the model exists but
+      // initialize_level hasn't yet populated it).
+      if (level === 0) continue;
+
+      result = {
+        game_id: gameId,
+        level,
+        points_required: Number(BigInt(data[valStart + 1])),
+        max_moves: Number(BigInt(data[valStart + 2])),
+        difficulty: Number(BigInt(data[valStart + 3])),
+        constraint_type: Number(BigInt(data[valStart + 4])),
+        constraint_value: Number(BigInt(data[valStart + 5])),
+        constraint_count: Number(BigInt(data[valStart + 6])),
+        constraint2_type: Number(BigInt(data[valStart + 7])),
+        constraint2_value: Number(BigInt(data[valStart + 8])),
+        constraint2_count: Number(BigInt(data[valStart + 9])),
+        mutator_id: Number(BigInt(data[valStart + 10])),
+      };
+    } catch {
+      continue;
+    }
+  }
+
+  return result;
+}
+
+/**
+ * After a start-game TX (create / createRun / startRun / replayLevel /
+ * startDailyGame / replayDailyLevel), parse the receipt for Game + GameSeed +
+ * GameLevel and seed the receipt store. This lets the client render the board
+ * without waiting for Torii to index the new entities.
+ *
+ * Returns true on full success. On any parse failure, leaves the store
+ * untouched and returns false — the Torii fallback path takes over.
+ */
+export function tryApplyStartGameReceipt(
+  events: ContractEvent[],
+  gameId: bigint,
+): boolean {
+  if (gameId <= 0n) return false;
+
+  const game = parseGameFromReceipt(events, gameId);
+  const seed = parseGameSeedFromReceipt(events, gameId);
+  const level = parseGameLevelFromReceipt(events, gameId);
+
+  if (!game || !seed || !level) return false;
+
+  useReceiptGameStore.getState().setStartGameReceipt({
+    gameId,
+    game: game.game,
+    seed: seed.seed,
+    level,
+  });
+
+  return true;
 }

--- a/client-budokan/src/dojo/systems.ts
+++ b/client-budokan/src/dojo/systems.ts
@@ -11,6 +11,7 @@ import {
 } from "@/utils/toast";
 import { useMoveStore } from "@/stores/moveTxStore";
 import { createLogger } from "@/utils/logger";
+import { tryApplyStartGameReceipt } from "./rpcReader";
 
 export type SystemCalls = ReturnType<typeof systems>;
 
@@ -212,12 +213,14 @@ export function systems({ client }: { client: IWorld }) {
       token_id: props.token_id,
       run_type: props.run_type,
     });
-    await handleTransaction(
+    const { events } = await handleTransaction(
       account,
       () => client.game.create({ account, ...props }),
       "Game has been started.",
     );
-    log.info("create success");
+    const gameId = BigInt(props.token_id);
+    const seeded = tryApplyStartGameReceipt(events, gameId);
+    log.info("create success", { receiptSeeded: seeded, game_id: gameId });
   };
 
   const createRun = async ({ account, ...props }: SystemTypes.CreateRun) => {
@@ -225,18 +228,21 @@ export function systems({ client }: { client: IWorld }) {
       game_id: props.game_id,
       run_type: props.run_type,
     });
-    await handleTransaction(
+    const { events } = await handleTransaction(
       account,
       () => client.game.createRun({ account, ...props }),
       "Run has been created.",
     );
-    log.info("createRun success");
+    const gameId = BigInt(props.game_id);
+    const seeded = tryApplyStartGameReceipt(events, gameId);
+    log.info("createRun success", { receiptSeeded: seeded, game_id: gameId });
   };
 
   const startRun = async ({ account, ...props }: SystemTypes.StartRun): Promise<{ game_id: bigint }> => {
     if (!client.story_system) throw new Error("Story system not available");
     const { events } = await handleTransaction(account, () => client.story_system!.startRun({ account, ...props }), "Story run started.");
     const gameId = extractStoryAttemptIdFromEvents(events, client.story_system.address, account.address);
+    if (gameId > 0n) tryApplyStartGameReceipt(events, gameId);
     return { game_id: gameId };
   };
 
@@ -244,6 +250,7 @@ export function systems({ client }: { client: IWorld }) {
     if (!client.story_system) throw new Error("Story system not available");
     const { events } = await handleTransaction(account, () => client.story_system!.replayLevel({ account, ...props }), "Story level replayed.");
     const gameId = extractStoryAttemptIdFromEvents(events, client.story_system.address, account.address);
+    if (gameId > 0n) tryApplyStartGameReceipt(events, gameId);
     return { game_id: gameId };
   };
 
@@ -361,6 +368,7 @@ export function systems({ client }: { client: IWorld }) {
         break;
       }
     }
+    if (gameId > 0n) tryApplyStartGameReceipt(events, gameId);
     return { game_id: gameId };
   };
 
@@ -389,6 +397,7 @@ export function systems({ client }: { client: IWorld }) {
         break;
       }
     }
+    if (gameId > 0n) tryApplyStartGameReceipt(events, gameId);
     return { game_id: gameId };
   };
 

--- a/client-budokan/src/hooks/useGame.tsx
+++ b/client-budokan/src/hooks/useGame.tsx
@@ -1,9 +1,10 @@
 import { useDojo } from "@/dojo/useDojo";
-import { useMemo, useEffect, useState } from "react";
+import { useMemo } from "react";
 import { getEntityIdFromKeys } from "@dojoengine/utils";
 import { useComponentValue } from "@dojoengine/react";
 import useDeepMemo from "./useDeepMemo";
 import { normalizeEntityId } from "@/utils/entityId";
+import { useReceiptGameStore } from "@/stores/receiptGameStore";
 
 export const useGame = ({
   gameId,
@@ -30,35 +31,27 @@ export const useGame = ({
   const component = useComponentValue(Game, gameKey);
   const seedComponent = useComponentValue(GameSeed, gameKey);
 
-  const game = useDeepMemo(() => {
+  // Receipt-based fast path: when a start-game TX has just confirmed, the
+  // receipt store holds the freshly-minted Game + GameSeed, so we skip the
+  // wait for Torii to index. Only honor it when the gameId matches.
+  const receiptGameId = useReceiptGameStore((s) => s.gameId);
+  const receiptGame = useReceiptGameStore((s) => s.game);
+  const receiptSeed = useReceiptGameStore((s) => s.seed);
+  const useReceipt =
+    gameId !== undefined &&
+    receiptGameId !== null &&
+    BigInt(gameId) === receiptGameId;
+
+  const toriiGame = useDeepMemo(() => {
     return component ? new GameClass(component) : null;
   }, [component]);
 
-  // Track if we need to retry fetching the seed
-  const [retryCount, setRetryCount] = useState(0);
+  const game = useReceipt && receiptGame ? receiptGame : toriiGame;
 
   const seed = useMemo(() => {
-    const s = seedComponent?.seed ? BigInt(seedComponent.seed) : BigInt(0);
-    return s;
-  }, [seedComponent, gameKey, retryCount]);
-
-  // Retry fetching seed if game exists but seed is missing
-  useEffect(() => {
-    if (game && !seedComponent && retryCount < 5) {
-      const delay = 500 * Math.pow(2, retryCount);
-      const timer = setTimeout(() => {
-        setRetryCount((prev) => prev + 1);
-      }, delay);
-      return () => clearTimeout(timer);
-    }
-  }, [game, seedComponent, retryCount]);
-
-  // Reset retry count when game changes
-  useEffect(() => {
-    setRetryCount(0);
-  }, [gameKey]);
-
-
+    if (useReceipt && receiptSeed != null) return receiptSeed;
+    return seedComponent?.seed ? BigInt(seedComponent.seed) : 0n;
+  }, [useReceipt, receiptSeed, seedComponent]);
 
   return { game, gameKey, seed };
 };

--- a/client-budokan/src/hooks/useGameLevel.tsx
+++ b/client-budokan/src/hooks/useGameLevel.tsx
@@ -1,11 +1,16 @@
 import { useDojo } from "@/dojo/useDojo";
-import { useMemo, useEffect, useState } from "react";
+import { useMemo } from "react";
 import { getEntityIdFromKeys } from "@dojoengine/utils";
 import { useComponentValue } from "@dojoengine/react";
+import type { Entity } from "@dojoengine/recs";
 import { ConstraintType } from "@/dojo/game/types/constraint";
 import { useMutatorDef } from "./useMutatorDef";
 import { applyStarThresholdModifier } from "@/dojo/game/types/level";
 import { normalizeEntityId } from "@/utils/entityId";
+import {
+  useReceiptGameStore,
+  type ReceiptGameLevelComponent,
+} from "@/stores/receiptGameStore";
 
 export interface GameLevelData {
   gameId: bigint;
@@ -26,12 +31,14 @@ export interface GameLevelData {
   star2Threshold: number;
 }
 
+type GameLevelComponent = ReceiptGameLevelComponent;
+
 /**
- * Hook to fetch the GameLevel model from RECS.
- * This model is written by the contract and contains the authoritative level configuration.
- * 
- * @param gameId - The game ID to fetch the level for
- * @returns The GameLevel data if available, or null if not yet synced
+ * Hook to fetch the GameLevel model.
+ *
+ * Source preference: receipt store (set by start-game TX) → Torii component.
+ * The receipt path lets a freshly-started game render its level config without
+ * waiting for Torii to index the new entity.
  */
 export const useGameLevel = ({
   gameId,
@@ -52,27 +59,30 @@ export const useGameLevel = ({
     return normalizeEntityId(rawKey);
   }, [gameId]);
 
-  const component = useComponentValue(GameLevel, gameKey ?? ("0x0" as Entity));
+  const toriiComponent = useComponentValue(
+    GameLevel,
+    gameKey ?? ("0x0" as Entity),
+  );
+
+  const receiptGameId = useReceiptGameStore((s) => s.gameId);
+  const receiptLevel = useReceiptGameStore((s) => s.level);
+  const useReceipt =
+    gameId !== undefined &&
+    receiptGameId !== null &&
+    BigInt(gameId) === receiptGameId;
+
+  // Kickstart pattern: prefer the receipt-cached level only until Torii syncs.
+  // Once toriiComponent arrives we yield to it — this ensures level-up writes
+  // (which the contract makes via level_system, not parsed from move
+  // receipts here) take effect without needing a refresh.
+  const component: GameLevelComponent | undefined = toriiComponent
+    ? (toriiComponent as GameLevelComponent)
+    : useReceipt && receiptLevel
+      ? receiptLevel
+      : undefined;
+
   const passiveMutatorId = component?.mutator_id ?? 0;
   const { data: passiveMutator } = useMutatorDef(passiveMutatorId);
-
-  // Track if we need to retry fetching
-  const [retryCount, setRetryCount] = useState(0);
-
-  // Retry fetching if component is missing but we expect it
-  useEffect(() => {
-    if (gameId !== undefined && !component && retryCount < 5) {
-      const timer = setTimeout(() => {
-        setRetryCount((prev) => prev + 1);
-      }, 500);
-      return () => clearTimeout(timer);
-    }
-  }, [gameId, component, retryCount]);
-
-  // Reset retry count when game changes
-  useEffect(() => {
-    setRetryCount(0);
-  }, [gameId]);
 
   const gameLevel = useMemo((): GameLevelData | null => {
     if (!component) return null;
@@ -81,7 +91,7 @@ export const useGameLevel = ({
     const modifier = passiveMutator?.starThresholdModifier ?? 128;
     const { star3Pct, star2Pct } = applyStarThresholdModifier(modifier);
     const data: GameLevelData = {
-      gameId: component.game_id,
+      gameId: BigInt(component.game_id),
       level: component.level,
       pointsRequired: component.points_required,
       maxMoves,
@@ -98,7 +108,7 @@ export const useGameLevel = ({
     };
 
     return data;
-  }, [component, retryCount, passiveMutator]);
+  }, [component, passiveMutator]);
 
   return gameLevel;
 };

--- a/client-budokan/src/stores/receiptGameStore.ts
+++ b/client-budokan/src/stores/receiptGameStore.ts
@@ -1,13 +1,58 @@
 import { create } from "zustand";
 import type { Game } from "@/dojo/game/models/game";
 
+/**
+ * Subset of the GameLevel RECS component shape needed by useGameLevel.
+ * Receipt-parsed levels populate this; useGameLevel transforms it into
+ * the public GameLevelData (applying star-threshold modifier).
+ */
+export interface ReceiptGameLevelComponent {
+  game_id: bigint;
+  level: number;
+  points_required: number;
+  max_moves: number;
+  difficulty: number;
+  constraint_type: number;
+  constraint_value: number;
+  constraint_count: number;
+  constraint2_type: number;
+  constraint2_value: number;
+  constraint2_count: number;
+  mutator_id: number;
+}
+
 interface ReceiptGameStore {
-  /** Game object parsed from the latest TX receipt — overrides Torii until it catches up */
+  /** Game object — receipt override for HUD/grid (move/bonus path or start-game) */
   game: Game | null;
+  /** Game-creation seed from the start-game TX receipt */
+  seed: bigint | null;
+  /** Initial GameLevel from the start-game TX receipt */
+  level: ReceiptGameLevelComponent | null;
+  /** Anchors all overrides — id-mismatched consumers ignore the cache */
+  gameId: bigint | null;
+
+  /** Update only the Game model (move/bonus path; preserves seed/level) */
   setGame: (game: Game | null) => void;
+
+  /** Atomic write for the start-game path: seeds game + seed + level together */
+  setStartGameReceipt: (params: {
+    gameId: bigint;
+    game: Game;
+    seed: bigint;
+    level: ReceiptGameLevelComponent;
+  }) => void;
+
+  /** Drop all overrides (on game switch / receipt-parse failure / navigate away) */
+  clear: () => void;
 }
 
 export const useReceiptGameStore = create<ReceiptGameStore>((set) => ({
   game: null,
+  seed: null,
+  level: null,
+  gameId: null,
   setGame: (game) => set({ game }),
+  setStartGameReceipt: ({ gameId, game, seed, level }) =>
+    set({ gameId, game, seed, level }),
+  clear: () => set({ gameId: null, game: null, seed: null, level: null }),
 }));

--- a/client-budokan/src/ui/components/Block.tsx
+++ b/client-budokan/src/ui/components/Block.tsx
@@ -40,6 +40,7 @@ const BlockContainer: React.FC<BlockProps> = ({
     state === GameState.GRAVITY2 ||
     state === GameState.GRAVITY_BONUS ||
     state === GameState.ADD_LINE_SHIFT;
+  const isDragging = state === GameState.DRAGGING;
 
   useEffect(() => {
     const element = ref.current;
@@ -79,7 +80,9 @@ const BlockContainer: React.FC<BlockProps> = ({
         transform: `translate(${x}px, ${y}px)`,
         transition: isGravity
           ? `transform ${transitionDuration / 1000}s linear`
-          : "none",
+          : isDragging
+            ? "transform 80ms ease-out"
+            : "none",
         cursor: isTxProcessing ? "wait" : "grab",
       }}
       onPointerDown={(e) => onPointerDown?.(e, block)}

--- a/client-budokan/src/ui/components/GameBoard.tsx
+++ b/client-budokan/src/ui/components/GameBoard.tsx
@@ -18,6 +18,13 @@ interface GameBoardProps {
   bonusDescription: string;
   onCascadeComplete?: () => void;
   forceTxProcessing?: boolean;
+  /**
+   * True while the contract-side level is transitioning. PlayScreen owns the
+   * computation because it has access to both the receipt-merged `game` and
+   * `toriiGame`; we OR it into effectiveTxProcessing so the grid stays locked
+   * until Torii catches up and the level-complete navigation fires.
+   */
+  levelTransitionPending: boolean;
 }
 
 const GameBoard: React.FC<GameBoardProps> = ({
@@ -29,6 +36,7 @@ const GameBoard: React.FC<GameBoardProps> = ({
   bonusDescription,
   onCascadeComplete,
   forceTxProcessing = false,
+  levelTransitionPending,
 }) => {
   const ROWS = 10;
   const COLS = 8;
@@ -39,7 +47,8 @@ const GameBoard: React.FC<GameBoardProps> = ({
   const [gridSize, setGridSize] = useState(40);
 
   const [isTxProcessing, setIsTxProcessing] = useState(false);
-  const effectiveTxProcessing = isTxProcessing || forceTxProcessing;
+  const effectiveTxProcessing =
+    isTxProcessing || forceTxProcessing || levelTransitionPending;
   const [nextLineHasBeenConsumed, setNextLineHasBeenConsumed] = useState(false);
   const [nextLineOverride, setNextLineOverride] = useState<number[] | null>(null);
 
@@ -92,7 +101,7 @@ const GameBoard: React.FC<GameBoardProps> = ({
           account={account}
           isTxProcessing={effectiveTxProcessing}
           setIsTxProcessing={setIsTxProcessing}
-          levelTransitionPending={game.levelTransitionPending}
+          levelTransitionPending={levelTransitionPending}
           onCascadeComplete={onCascadeComplete}
           onNextLineUpdate={setNextLineOverride}
         />

--- a/client-budokan/src/ui/components/Grid.tsx
+++ b/client-budokan/src/ui/components/Grid.tsx
@@ -250,8 +250,16 @@ const Grid: React.FC<GridProps> = ({
 
     const cellX = clientXToCellX(clientX);
     const delta = cellX - dragStartXRef.current;
-    const newX = initialXRef.current + delta;
+    // Snap to integer cells during drag (not just at release): keeps the
+    // visual position and the eventual landing column in lockstep, so a
+    // block dragged flush against the wall or an obstacle actually lands
+    // there instead of rounding back by one when the cursor is mid-cell.
+    const newX = Math.round(initialXRef.current + delta);
     const bounded = Math.max(0, Math.min(gridWidth - dragging.width, newX));
+    // Sub-cell pointer wobble re-enters this handler with the same snapped
+    // column. Skipping the setBlocks call avoids re-allocating the blocks
+    // array (and the [blocks] effect chain) per pointermove event.
+    if (bounded === draggedXRef.current) return;
 
     if (!checkBlocked(initialXRef.current, bounded, dragging.y, dragging.width, dragging.id)) {
       draggedXRef.current = bounded;
@@ -283,8 +291,8 @@ const Grid: React.FC<GridProps> = ({
     }
 
     const startX = initialXRef.current;
-    const finalX = Math.round(draggedXRef.current);
-    const hasMoved = Math.trunc(finalX) !== Math.trunc(startX);
+    const finalX = draggedXRef.current;
+    const hasMoved = finalX !== startX;
 
     setBlocks((prev) =>
       prev.map((b) => b.id === dragging.id ? { ...b, x: hasMoved ? finalX : startX } : b),

--- a/client-budokan/src/ui/pages/PlayScreen.tsx
+++ b/client-budokan/src/ui/pages/PlayScreen.tsx
@@ -81,9 +81,11 @@ const PlayScreen: React.FC = () => {
     return toriiGame;
   }, [toriiGame, receiptGame]);
 
-  // Clear receipt game when switching to a different game (navigation)
+  // Clear ALL receipt overrides when switching games (navigation). This drops
+  // stale cached seed/level/gameId from a previous game so the new game
+  // either uses its own start-game receipt or falls back to Torii cleanly.
   useEffect(() => {
-    useReceiptGameStore.getState().setGame(null);
+    useReceiptGameStore.getState().clear();
   }, [gameId]);
 
   const grid = useGrid({ gameId: game?.id ?? 0n, shouldLog: true });
@@ -171,12 +173,12 @@ const PlayScreen: React.FC = () => {
     prevBossLevelRef.current = level;
   }, [game?.level, playSfx, setMusicContext, setMusicPlaylist]);
 
+  // Show the spinner whenever we transition to a new gameId; the
+  // receipt-driven effect below clears it the instant the start-game TX
+  // populates useReceiptGameStore (or as soon as Torii catches up on
+  // cold-load / refresh).
   useEffect(() => {
     setIsGameLoading(true);
-    // 30s is the worst-case budget for a Budokan-deep-link landing where we
-    // also need create_run to confirm before Torii indexes the new Game model.
-    const timer = setTimeout(() => setIsGameLoading(false), 30000);
-    return () => clearTimeout(timer);
   }, [gameId]);
 
   useEffect(() => {

--- a/client-budokan/src/ui/pages/PlayScreen.tsx
+++ b/client-budokan/src/ui/pages/PlayScreen.tsx
@@ -131,6 +131,18 @@ const PlayScreen: React.FC = () => {
   const targetScore = effectiveGameLevel?.pointsRequired ?? 0;
   const maxMoves = effectiveGameLevel?.maxMoves ?? 0;
 
+  // Level-transition lock: covers two cases that should both freeze the grid.
+  //   1. The contract has cleared blocks (blocksRaw === 0n) but hasn't ended
+  //      the game — Game.levelTransitionPending captures this directly.
+  //   2. The receipt-merged `game` already shows the next level but `toriiGame`
+  //      hasn't synced yet — without this, the receipt unlocks the grid before
+  //      PlayScreen's toriiGame-driven nav effect can move the player to the
+  //      level-complete dialog, letting them play a free move on the new level.
+  const levelTransitionPending =
+    !!game &&
+    (game.levelTransitionPending ||
+      (!!toriiGame && game.level > toriiGame.level));
+
   const [isGameOverOpen, setIsGameOverOpen] = useState(false);
   const [isVictoryOpen, setIsVictoryOpen] = useState(false);
   const showEndlessGreeting = useNavigationStore((s) => s.showEndlessGreeting);
@@ -598,6 +610,7 @@ const PlayScreen: React.FC = () => {
               bonusDescription={bonusDescription}
               onCascadeComplete={handleCascadeComplete}
               forceTxProcessing={surrendering}
+              levelTransitionPending={levelTransitionPending}
             />
           </div>
         )}
@@ -613,6 +626,7 @@ const PlayScreen: React.FC = () => {
               bonusDescription={bonusDescription}
               onCascadeComplete={handleCascadeComplete}
               forceTxProcessing={surrendering}
+              levelTransitionPending={levelTransitionPending}
             />
           </div>
         )}


### PR DESCRIPTION
## Summary
- **Receipt-based fast sync for game start (all entry paths).** Cuts the 5–15 s of post-TX spinner on EGC deep-link, daily, story start, and replay paths down to ~1–2 s by parsing `Game` / `GameSeed` / `GameLevel` out of the start-game TX receipt instead of waiting for Torii to index them. Retires three retry loops: `useGame` exponential seed retry (15.5 s budget), `useGameLevel` fixed level retry (2.5 s), and the `PlayScreen` 30 s hard timeout. Same pattern as the existing receipt sync for moves/bonuses.
- **Integer-snap drag with smooth cell-to-cell motion.** Blocks now snap to integer cells during `onDragMove` (not only on release), so they reach the target wall or clip flush against an obstacle even when the cursor stops mid-cell — fixes the "block lands one cell short" desktop bug. An 80 ms `ease-out` CSS transition on the SVG `<g>` during `DRAGGING` keeps the motion smooth between snaps. A same-value guard in `onDragMove` skips redundant `setBlocks` calls so sub-cell pointer wobble no longer triggers a `Maximum update depth exceeded` warning.

## Changes
| Area | Files |
|---|---|
| Receipt parsers / store | `client-budokan/src/dojo/rpcReader.ts`, `client-budokan/src/stores/receiptGameStore.ts` |
| System-call wrappers | `client-budokan/src/dojo/systems.ts` (create, createRun, startRun, replayLevel, startDailyGame, replayDailyLevel) |
| Hooks | `client-budokan/src/hooks/useGame.tsx`, `client-budokan/src/hooks/useGameLevel.tsx` |
| Pages | `client-budokan/src/ui/pages/PlayScreen.tsx` |
| Drag UX | `client-budokan/src/ui/components/Block.tsx`, `client-budokan/src/ui/components/Grid.tsx` |

No contract changes. No new dependencies. `pnpm tsc --noEmit` and `pnpm build` clean.

## Test plan
- [ ] EGC deep-link (settings 51): open `/play/<unstarted_token_id>` — board playable within 1–2 s of TX confirmation
- [ ] Daily start / replay: same fast load
- [ ] Story start / replay: same fast load
- [ ] Refresh during play (Torii fallback): reloading mid-game still loads the board (slower path is still alive)
- [ ] Drag a block flush against the right wall and release — lands at the wall
- [ ] Drag a block toward another block in the same row — lands flush against it, no one-cell gap
- [ ] Drag motion looks smooth (slides between cells, no teleport)
- [ ] No `Maximum update depth exceeded` warning during drag
- [ ] Bonus moves (Hammer / Totem / Wave) still work — receipt-game HUD updates instantly

🤖 Generated with [Claude Code](https://claude.com/claude-code)